### PR TITLE
Add Gitlab support to Docker::Registry

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 local/
 cpanfile.snapshot
+/Docker-Registry-*.tar.gz
+/Docker-Registry-*/
+/Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM perl:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY cpanfile .
+RUN cpanm --installdeps .
+
+COPY . .
+
+RUN prove -lv t/*
+RUN cpanm .

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,0 +1,62 @@
+use strict;
+use warnings;
+
+use 5.014001;
+
+use ExtUtils::MakeMaker;
+
+my %WriteMakefileArgs = (
+  "ABSTRACT" => "A client for talking to Docker Registries",
+  "AUTHOR" => "Jose Luis Mart\x{ed}nez <joseluis.martinez\@capside.com>",
+  "CONFIGURE_REQUIRES" => {
+    "ExtUtils::MakeMaker" => 0
+  },
+  "DISTNAME" => "Docker-Registry",
+  "LICENSE" => "apache",
+  "MIN_PERL_VERSION" => "5.014001",
+  "NAME" => "Docker::Registry",
+  "PREREQ_PM" => {
+    "HTTP::Headers" => 0,
+    "HTTP::Tiny" => 0,
+    "IO::Socket::SSL" => 0,
+    "JSON::MaybeXS" => 0,
+    "Moose" => 0,
+    "MooseX::Types::Moose" => 0,
+    "Throwable::Error" => 0
+  },
+  "TEST_REQUIRES" => {
+    "Sub::Override" => 0,
+    "Test::Exception" => 0,
+    "Test::More" => 0
+  },
+  "VERSION" => "0.03",
+  "test" => {
+    "TESTS" => "t/*.t"
+  }
+);
+
+
+my %FallbackPrereqs = (
+  "HTTP::Headers" => 0,
+  "HTTP::Tiny" => 0,
+  "IO::Socket::SSL" => 0,
+  "JSON::MaybeXS" => 0,
+  "Moose" => 0,
+  "MooseX::Types::Moose" => 0,
+  "Sub::Override" => 0,
+  "Test::Exception" => 0,
+  "Test::More" => 0,
+  "Throwable::Error" => 0
+);
+
+
+unless ( eval { ExtUtils::MakeMaker->VERSION(6.63_03) } ) {
+  delete $WriteMakefileArgs{TEST_REQUIRES};
+  delete $WriteMakefileArgs{BUILD_REQUIRES};
+  $WriteMakefileArgs{PREREQ_PM} = \%FallbackPrereqs;
+}
+
+delete $WriteMakefileArgs{CONFIGURE_REQUIRES}
+  unless eval { ExtUtils::MakeMaker->VERSION(6.52) };
+
+WriteMakefile(%WriteMakefileArgs);

--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'HTTP::Tiny';
 requires 'HTTP::Headers';
 requires 'Throwable::Error';
 requires 'IO::Socket::SSL';
+requires 'MooseX::Types::Moose';
 
 feature 'gcr-registry', 'Support for GCR' => sub {
   requires 'Crypt::JWT';
@@ -12,13 +13,17 @@ feature 'gcr-registry', 'Support for GCR' => sub {
   requires 'URI';
 };
 
-feature 'ecr-registry', 'Support for ECR' => sub {
+feature 'ecr-registry', 'support for ecr' => sub {
   requires 'Paws';
+};
+
+feature 'gitlab-registry', 'support for gitlab' => sub {
 };
 
 on test => sub {
   requires 'Test::More';
   requires 'Test::Exception';
+  requires 'Sub::Override';
 };
 
 on develop => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -31,4 +31,5 @@ on develop => sub {
   requires 'Dist::Zilla::Plugin::Prereqs::FromCPANfile';
   requires 'Dist::Zilla::Plugin::VersionFromModule';
   requires 'Dist::Zilla::PluginBundle::Git';
+  requires 'Dist::Zilla::Plugin::CopyFilesFromBuild::Filtered';
 };

--- a/dist.ini
+++ b/dist.ini
@@ -15,10 +15,14 @@ dir = bin
 
 [MakeMaker]
 
+[CopyFilesFromBuild::Filtered]
+copy = Makefile.PL
+
 [@Git]
 allow_dirty = dist.ini
 allow_dirty = Changes
 allow_dirty = README
+allow_dirty = Makefile.PL
 
 [Prereqs::FromCPANfile]
 

--- a/examples/gitlab.pl
+++ b/examples/gitlab.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+
+use Data::Dumper;
+use Docker::Registry::Gitlab;
+use Docker::Registry::Auth::Gitlab;
+
+my $repo = $ARGV[0];
+
+my $r = Docker::Registry::Gitlab->new(
+    username => 'username',
+    password => 'personaltoken',
+    defined $repo ? (repo => $repo) : (),
+);
+
+$r->caller->debug(1);
+
+if (defined $repo) {
+    print Dumper($r->repository_tags(repository => $repo));
+}
+else {
+    my $repos = $r->repositories;
+    print Dumper($repos);
+
+    foreach my $r (@{ $repos->repositories }) {
+        print Dumper($r->repository_tags(repository => $r));
+    }
+}

--- a/examples/gitlab.pl
+++ b/examples/gitlab.pl
@@ -7,8 +7,8 @@ use Docker::Registry::Auth::Gitlab;
 my $repo = $ARGV[0];
 
 my $r = Docker::Registry::Gitlab->new(
-    username => 'username',
-    password => 'personaltoken',
+    username     => 'username',
+    access_token => 'personaltoken',
     defined $repo ? (repo => $repo) : (),
 );
 

--- a/lib/Docker/Registry/Auth/Gitlab.pm
+++ b/lib/Docker/Registry/Auth/Gitlab.pm
@@ -1,0 +1,152 @@
+package Docker::Registry::Auth::Gitlab;
+use Moose;
+use namespace::autoclean;
+
+# ABSTRACT: Authentication module for gitlab registry
+
+with 'Docker::Registry::Auth';
+
+use Docker::Registry::Types qw(DockerRegistryURI);
+use HTTP::Tiny;
+use JSON::MaybeXS qw(decode_json);
+
+has token => (
+    is       => 'ro',
+    isa      => 'Str',
+    lazy     => 1,
+    builder => 'get_token',
+);
+
+has username => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has password => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has jwt => (
+    is      => 'ro',
+    isa     => DockerRegistryURI,
+    coerce  => 1,
+    default => 'https://gitlab.com/jwt/auth',
+);
+
+has repo => (
+    is        => 'ro',
+    isa       => 'Str',
+    predicate => 'has_repo',
+);
+
+sub _build_scope {
+    my $self = shift;
+
+    if ($self->has_repo) {
+        return sprintf("repository:%s:pull,push", $self->repo);
+    }
+    else {
+        return 'registry:catalog:*';
+    }
+}
+
+sub _build_token_uri {
+    my $self = shift;
+
+    my $uri = $self->jwt->clone;
+
+    $uri->query_form(
+        service       => 'container_registry',
+        scope         => $self->_build_scope,
+        client_id     => 'docker',
+        offline_token => 'true',
+    );
+
+    $uri->userinfo(join(':', $self->username, $self->password));
+    return $uri;
+}
+
+sub get_token {
+    my $self = shift;
+
+    my $uri = $self->_build_token_uri;
+
+    my $ua = HTTP::Tiny->new();
+    my $res = $ua->get($uri);
+
+    if ($res->{success}) {
+        return decode_json($res->{content})->{token};
+    }
+
+    die "Unable to get token from gitlab!";
+}
+
+sub authorize {
+    my ($self, $request) = @_;
+
+    $request->header('Authorization', 'Bearer ' . $self->token);
+    $request->header('Accept',
+        'application/vnd.docker.distribution.manifest.v2+json');
+
+    return $request;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+__END__
+
+=head1 DESCRIPTION
+
+Authenticate against gitlab registry
+
+=head1 SYNOPSIS
+
+    use Docker::Registry::Auth::Gitlab;
+    use HTTP::Tiny;
+
+    my $auth = Docker::Registry::Auth::Gitlab->new(
+        username => 'foo',
+        password => 'bar',
+    );
+
+    my $req = $auth->authorize(HTTP::Request->new('GET', 'https://foo.bar.nl'));
+    my $res = HTTP::Tiny->new()->get($req);
+
+=head1 ATTRIBUTES
+
+=head2 username
+
+Your username at gitlab.
+
+=head2 password
+
+The access token you get from
+L<gitlab|https://gitlab.com/profile/personal_access_tokens> with
+'read_registry' access.
+
+=head2 repo
+
+The repository you request access to.
+
+=head2 jwt
+
+The endpoint to request the JWT token from, defaults to
+'https://gitlab.com/jwt/auth'. You can use a 'Str' or an URI object.
+
+=head2 token
+
+The token received from gitlab.
+
+=head1 METHODS
+
+=head2 authorize
+
+Implements the method as required by C<Docker::Registry::Auth>. Add the
+"Authorization" header to the request with the "Bearer" token.
+
+=head2 SEE ALSO
+
+C<Docker::Registry::Auth>, C<Docker::Registery::Types> and C<Docker::Registry::Gitlab>.

--- a/lib/Docker/Registry/Auth/Gitlab.pm
+++ b/lib/Docker/Registry/Auth/Gitlab.pm
@@ -10,20 +10,13 @@ use Docker::Registry::Types qw(DockerRegistryURI);
 use HTTP::Tiny;
 use JSON::MaybeXS qw(decode_json);
 
-has token => (
-    is       => 'ro',
-    isa      => 'Str',
-    lazy     => 1,
-    builder => 'get_token',
-);
-
 has username => (
     is       => 'ro',
     isa      => 'Str',
     required => 1,
 );
 
-has password => (
+has access_token => (
     is       => 'ro',
     isa      => 'Str',
     required => 1,
@@ -41,6 +34,14 @@ has repo => (
     isa       => 'Str',
     predicate => 'has_repo',
 );
+
+has bearer_token => (
+    is       => 'ro',
+    isa      => 'Str',
+    lazy     => 1,
+    builder => 'get_bearer_token',
+);
+
 
 sub _build_scope {
     my $self = shift;
@@ -65,11 +66,11 @@ sub _build_token_uri {
         offline_token => 'true',
     );
 
-    $uri->userinfo(join(':', $self->username, $self->password));
+    $uri->userinfo(join(':', $self->username, $self->access_token));
     return $uri;
 }
 
-sub get_token {
+sub get_bearer_token {
     my $self = shift;
 
     my $uri = $self->_build_token_uri;
@@ -87,7 +88,7 @@ sub get_token {
 sub authorize {
     my ($self, $request) = @_;
 
-    $request->header('Authorization', 'Bearer ' . $self->token);
+    $request->header('Authorization', 'Bearer ' . $self->bearer_token);
     $request->header('Accept',
         'application/vnd.docker.distribution.manifest.v2+json');
 
@@ -109,7 +110,7 @@ Authenticate against gitlab registry
 
     my $auth = Docker::Registry::Auth::Gitlab->new(
         username => 'foo',
-        password => 'bar',
+        access_token => 'bar',
     );
 
     my $req = $auth->authorize(HTTP::Request->new('GET', 'https://foo.bar.nl'));
@@ -121,7 +122,7 @@ Authenticate against gitlab registry
 
 Your username at gitlab.
 
-=head2 password
+=head2 access_token
 
 The access token you get from
 L<gitlab|https://gitlab.com/profile/personal_access_tokens> with
@@ -136,11 +137,11 @@ The repository you request access to.
 The endpoint to request the JWT token from, defaults to
 'https://gitlab.com/jwt/auth'. You can use a 'Str' or an URI object.
 
-=head2 token
-
-The token received from gitlab.
-
 =head1 METHODS
+
+=head2 get_bearer_token
+
+The builder of the C<bearer_token> attribute.
 
 =head2 authorize
 

--- a/lib/Docker/Registry/Auth/Gitlab.pm
+++ b/lib/Docker/Registry/Auth/Gitlab.pm
@@ -144,9 +144,9 @@ The token received from gitlab.
 
 =head2 authorize
 
-Implements the method as required by C<Docker::Registry::Auth>. Add the
+Implements the method as required by L<Docker::Registry::Auth>. Add the
 "Authorization" header to the request with the "Bearer" token.
 
 =head2 SEE ALSO
 
-C<Docker::Registry::Auth>, C<Docker::Registery::Types> and C<Docker::Registry::Gitlab>.
+L<Docker::Registry::Auth>, L<Docker::Registery::Types> and L<Docker::Registry::Gitlab>.

--- a/lib/Docker/Registry/Gitlab.pm
+++ b/lib/Docker/Registry/Gitlab.pm
@@ -21,7 +21,7 @@ has 'username' => (
     required => 1,
 );
 
-has 'password' => (
+has 'access_token' => (
     is       => 'ro',
     isa      => 'Str',
     required => 1,
@@ -44,10 +44,10 @@ has '+auth' => (
     default => sub {
         my $self = shift;
         return Docker::Registry::Auth::Gitlab->new(
-            username => $self->username,
-            password => $self->password,
-            $self->has_jwt ? ( jwt => $self->jwt ) : (),
-            $self->has_repo ? ( repo => $self->repo ) : (),
+            username     => $self->username,
+            access_token => $self->access_token,
+            $self->has_jwt  ? (jwt  => $self->jwt)  : (),
+            $self->has_repo ? (repo => $self->repo) : (),
         );
     },
 );
@@ -77,7 +77,7 @@ Connect and do things with the gitlab registry
     use Docker::Registry::Gitlab;
     my $registry = Docker::Registry::Gitlab->new(
         username => 'foo',
-        password => 'bar', # your private token at gitlab
+        access_token => 'bar', # your private token at gitlab
     );
 
 =head1 ATTRIBUTES
@@ -90,7 +90,7 @@ The endpoint of the registry, defaults to 'https://registry.gitlab.com'.
 
 Your username at gitlab
 
-=head2 password
+=head2 access_token
 
 The access token you get from
 L<gitlab|https://gitlab.com/profile/personal_access_tokens> with

--- a/lib/Docker/Registry/Gitlab.pm
+++ b/lib/Docker/Registry/Gitlab.pm
@@ -1,0 +1,123 @@
+package Docker::Registry::Gitlab;
+use Moose;
+extends 'Docker::Registry::V2';
+use namespace::autoclean;
+
+# ABSTRACT: Be able to talk to the gitlab registry
+
+use Docker::Registry::Types qw(DockerRegistryURI);
+
+has '+url' => (
+    lazy    => 1,
+    default => sub {
+        my $self = shift;
+        'https://registry.gitlab.com';
+    }
+);
+
+has 'username' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has 'password' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has 'jwt' => (
+    is        => 'ro',
+    isa       => DockerRegistryURI,
+    predicate => 'has_jwt',
+);
+
+has 'repo' => (
+    is        => 'ro',
+    isa       => 'Str',
+    predicate => 'has_repo',
+);
+
+has '+auth' => (
+    lazy    => 1,
+    default => sub {
+        my $self = shift;
+        return Docker::Registry::Auth::Gitlab->new(
+            username => $self->username,
+            password => $self->password,
+            $self->has_jwt ? ( jwt => $self->jwt ) : (),
+            $self->has_repo ? ( repo => $self->repo ) : (),
+        );
+    },
+);
+
+around 'repositories' => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    if ($ENV{GITLAB_SCOPE}) {
+        $self->$orig(@_);
+    }
+    else {
+        ...;
+    }
+};
+
+__PACKAGE__->meta->make_immutable;
+
+__END__
+
+=head1 DESCRIPTION
+
+Connect and do things with the gitlab registry
+
+=head1 SYNOPSIS
+
+    use Docker::Registry::Gitlab;
+    my $registry = Docker::Registry::Gitlab->new(
+        username => 'foo',
+        password => 'bar', # your private token at gitlab
+    );
+
+=head1 ATTRIBUTES
+
+=head2 url
+
+The endpoint of the registry, defaults to 'https://registry.gitlab.com'.
+
+=head2 username
+
+Your username at gitlab
+
+=head2 password
+
+The access token you get from
+L<gitlab|https://gitlab.com/profile/personal_access_tokens> with
+'read_registry' access.
+
+=head2 repo
+
+The repository you want to query.
+
+=head2 jwt
+
+The endpoint to request the JWT token from, if none supplied the default
+of L<Docker::Registry::Auth::Gitlab> will be used.
+
+=head1 METHODS
+
+=head2 repositories
+
+Unimplemented code path unless GITLAB_SCOPE is set as an environment variable.
+
+=head1 BUGS
+
+Because Gitlab doesn't support wild cards in scopes (yet!), you are not
+able to call certain functions. L<Docker::Registry::Gitlab/repositories>
+being one of them. For more information see:
+L<https://gitlab.com/gitlab-org/gitlab-ce/issues/47497>
+
+=head1 SEE ALSO
+
+L<Docker::Registry::Auth::Gitlab> and L<Docker::Registry::V2>.

--- a/lib/Docker/Registry/Types.pm
+++ b/lib/Docker/Registry/Types.pm
@@ -15,7 +15,7 @@ use MooseX::Types -declare => [
 class_type DockerRegistryURI, {class => 'URI' };
 coerce DockerRegistryURI, from Str, via { return URI->new($_); };
 
-__PACKAGE__->meta->make_immutable;
+1;
 
 __END__
 

--- a/lib/Docker/Registry/Types.pm
+++ b/lib/Docker/Registry/Types.pm
@@ -1,0 +1,45 @@
+package Docker::Registry::Types;
+use warnings;
+use strict;
+
+# ABSTRACT: Moose like types defined for Docker::Registry
+
+use MooseX::Types::Moose qw(Str);
+use URI;
+use MooseX::Types -declare => [
+    qw(
+        DockerRegistryURI
+    )
+];
+
+class_type DockerRegistryURI, {class => 'URI' };
+coerce DockerRegistryURI, from Str, via { return URI->new($_); };
+
+__PACKAGE__->meta->make_immutable;
+
+__END__
+
+=head1 DESCRIPTION
+
+Defines custom types for Docker::Registry modules
+
+=head1 SYNOPSIS
+
+    package Foo;
+    use Moose;
+
+    use Docker::Registry::Types qw(DockerRegistryURI);
+
+    has bar => (
+        is => 'ro',
+        isa => DockerRegistryURI,
+    );
+
+
+=head1 TYPES
+
+=head2 DockerRegistryURI
+
+Allows a scalar URI, eq 'https://foo.bar.nl', or a URI object.
+
+=cut

--- a/t/000-types.t
+++ b/t/000-types.t
@@ -1,0 +1,14 @@
+use warnings;
+use strict;
+
+use Test::More;
+
+use Docker::Registry::Types qw(DockerRegistryURI);
+use URI;
+
+my $uri = URI->new();
+ok(DockerRegistryURI->check($uri), "isa URI");
+ok(DockerRegistryURI->coerce('https://foo.bar.nl'), "coerced URI");
+
+
+done_testing;

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -69,7 +69,7 @@ SKIP: {
         . " test. Optionally set GITLAB_JWT if you want to test against a"
         . " self-hosted server. GITLAB_REPO can also be set.";
 
-    skip "LIVE tests" unless grep { /^GITLAB_/ } keys %ENV;
+    skip "LIVE tests", 1 unless grep { /^GITLAB_/ } keys %ENV;
 
     my $auth = Docker::Registry::Auth::Gitlab->new(
         username     => $ENV{GITLAB_USERNAME},

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -65,11 +65,12 @@ use Docker::Registry::Auth::Gitlab;
 
 SKIP: {
 
-    note "Live test, set GITLAB_USERNAME, GITLAB_access_token to run this"
-        . " test. Optionally set GITLAB_JWT if you want to test against a"
-        . " self-hosted server. GITLAB_REPO can also be set.";
+    my $msg = "Live test, set GITLAB_USERNAME, GITLAB_TOKEN to run this"
+    . " test. Optionally set GITLAB_JWT if you want to test against a"
+    . " self-hosted server. GITLAB_REPO can also be set.";
 
-    skip "LIVE tests", 1 unless grep { /^GITLAB_/ } keys %ENV;
+    skip($msg, 1) unless grep { /^GITLAB_/ } keys %ENV;
+    note "Running live tests";
 
     my $auth = Docker::Registry::Auth::Gitlab->new(
         username     => $ENV{GITLAB_USERNAME},

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -1,0 +1,85 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use Sub::Override;
+use HTTP::Request;
+
+use Docker::Registry::Auth::Gitlab;
+
+{
+    my $auth = Docker::Registry::Auth::Gitlab->new(
+        username => 'foo',
+        password => 'bar',
+    );
+
+    my $jwt = $auth->jwt;
+    isa_ok($jwt, 'URI', "Got a JWT URI");
+
+    my $scope = $auth->_build_scope;
+    is($scope, 'registry:catalog:*', "scope is set to 'registry:catalog:*'");
+
+    {
+        # Cannot change the value, so bypass it :)
+        my $attr = $auth->meta->find_attribute_by_name('repo');
+        $attr->set_value($auth, 'foobar');
+
+        my $scope = $auth->_build_scope;
+        is($scope, 'repository:foobar:pull,push',
+            "scope is set to 'repository:foobar:pull,push'");
+    }
+
+    my $uri = $auth->_build_token_uri;
+    isa_ok($uri, 'URI', ".. and we have a token URI");
+    is($uri->host,     'gitlab.com', ".. with the correct hostname");
+    is($uri->userinfo, 'foo:bar',    ".. and the correct login details");
+
+    # Override HTTP::Tiny get so we don't need a network connection
+    my $override = Sub::Override->new(
+        "HTTP::Tiny::get" => sub {
+            return {
+                success => 1,
+                content => '{"token":"mysupersecrettoken"}',
+            };
+        }
+    );
+
+    is($auth->token, "mysupersecrettoken",
+        "Go the super secret token from gitlab!");
+
+    my $req = HTTP::Request->new('GET', $uri);
+    $req = $auth->authorize($req);
+
+    isa_ok($req, "HTTP::Request", "->authorize works too");
+    is(
+        $req->headers->header("authorization"),
+        "Bearer mysupersecrettoken",
+        ".. with the correct header"
+    );
+
+    $override->restore;
+}
+
+SKIP: {
+
+    note "Live test, set GITLAB_USERNAME, GITLAB_TOKEN to run this"
+    . " test. Optionally set GITLAB_JWT if you want to test against a"
+    . " self-hosted server. GITLAB_REPO can also be set.";
+
+    skip "LIVE tests" unless grep { /^GITLAB_/ } keys %ENV;
+
+    my $auth = Docker::Registry::Auth::Gitlab->new(
+        username => $ENV{GITLAB_USERNAME},
+        password => $ENV{GITLAB_TOKEN},
+        $ENV{GITLAB_JWT}  ? (jwt  => $ENV{GITLAB_JWT})  : (),
+        $ENV{GITLAB_REPO} ? (repo => $ENV{GITLAB_REPO}) : (),
+    );
+
+    my $token = $auth->token;
+    isnt($token, undef, "We got '$token' from gitlab");
+
+}
+done_testing;

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -12,8 +12,8 @@ use Docker::Registry::Auth::Gitlab;
 
 {
     my $auth = Docker::Registry::Auth::Gitlab->new(
-        username => 'foo',
-        password => 'bar',
+        username     => 'foo',
+        access_token => 'bar',
     );
 
     my $jwt = $auth->jwt;
@@ -33,7 +33,7 @@ use Docker::Registry::Auth::Gitlab;
     }
 
     my $uri = $auth->_build_token_uri;
-    isa_ok($uri, 'URI', ".. and we have a token URI");
+    isa_ok($uri, 'URI', ".. and we have a access_token URI");
     is($uri->host,     'gitlab.com', ".. with the correct hostname");
     is($uri->userinfo, 'foo:bar',    ".. and the correct login details");
 
@@ -42,12 +42,12 @@ use Docker::Registry::Auth::Gitlab;
         "HTTP::Tiny::get" => sub {
             return {
                 success => 1,
-                content => '{"token":"mysupersecrettoken"}',
+                content => '{"token":"mysupersecretaccess_token"}',
             };
         }
     );
 
-    is($auth->token, "mysupersecrettoken",
+    is($auth->bearer_token, "mysupersecretaccess_token",
         "Go the super secret token from gitlab!");
 
     my $req = HTTP::Request->new('GET', $uri);
@@ -56,7 +56,7 @@ use Docker::Registry::Auth::Gitlab;
     isa_ok($req, "HTTP::Request", "->authorize works too");
     is(
         $req->headers->header("authorization"),
-        "Bearer mysupersecrettoken",
+        "Bearer mysupersecretaccess_token",
         ".. with the correct header"
     );
 
@@ -65,20 +65,20 @@ use Docker::Registry::Auth::Gitlab;
 
 SKIP: {
 
-    note "Live test, set GITLAB_USERNAME, GITLAB_TOKEN to run this"
-    . " test. Optionally set GITLAB_JWT if you want to test against a"
-    . " self-hosted server. GITLAB_REPO can also be set.";
+    note "Live test, set GITLAB_USERNAME, GITLAB_access_token to run this"
+        . " test. Optionally set GITLAB_JWT if you want to test against a"
+        . " self-hosted server. GITLAB_REPO can also be set.";
 
     skip "LIVE tests" unless grep { /^GITLAB_/ } keys %ENV;
 
     my $auth = Docker::Registry::Auth::Gitlab->new(
-        username => $ENV{GITLAB_USERNAME},
-        password => $ENV{GITLAB_TOKEN},
+        username     => $ENV{GITLAB_USERNAME},
+        access_token => $ENV{GITLAB_TOKEN},
         $ENV{GITLAB_JWT}  ? (jwt  => $ENV{GITLAB_JWT})  : (),
         $ENV{GITLAB_REPO} ? (repo => $ENV{GITLAB_REPO}) : (),
     );
 
-    my $token = $auth->token;
+    my $token = $auth->bearer_token;
     isnt($token, undef, "We got '$token' from gitlab");
 
 }

--- a/t/400-gitlab.t
+++ b/t/400-gitlab.t
@@ -1,0 +1,81 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use Docker::Registry::Gitlab;
+use Docker::Registry::Auth::None;
+
+package TestIO::Fake {
+  use Moose;
+  with 'Docker::Registry::IO';
+
+  has response_to_return => (is => 'rw', isa => 'Docker::Registry::Response');
+
+  sub send_request {
+    my $self = shift;
+    return $self->response_to_return;
+  }
+}
+
+my $auth = Docker::Registry::Auth::None->new;
+
+my $io = TestIO::Fake->new(
+  response_to_return => response_200(''),
+);
+
+sub response_200 {
+  my ($content) = @_;
+  registry_response(200, $content);
+}
+
+sub registry_response {
+  my ($status, $content) = @_;
+  return Docker::Registry::Response->new(
+    content => $content,
+    status => $status,
+    headers => {},
+  );
+}
+
+my $d = Docker::Registry::Gitlab->new(
+    username => 'username',
+    password => 'password',
+    caller => $io,
+    auth   => $auth,
+);
+
+{
+  $io->response_to_return(
+    response_200('{"repositories":["test2-registry","test1-registry"]}'),
+  );
+
+throws_ok(
+    sub {
+        my $result = $d->repositories;
+        isa_ok($result, 'Docker::Registry::Result::Repositories');
+        cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
+        cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
+    },
+    qr/Unimplemented/,
+    "This doesn't work for now"
+);
+
+}
+
+{
+  $io->response_to_return(
+    response_200('{"name":"test2-registry","tags":["version1"]}'), 
+  );
+
+  my $result = $d->repository_tags(repository => 'test2-registry');
+
+  isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
+  cmp_ok($result->name, 'eq', 'test2-registry');
+  cmp_ok($result->tags->[0], 'eq', 'version1');
+}
+
+done_testing;

--- a/t/400-gitlab.t
+++ b/t/400-gitlab.t
@@ -10,72 +10,71 @@ use Docker::Registry::Gitlab;
 use Docker::Registry::Auth::None;
 
 package TestIO::Fake {
-  use Moose;
-  with 'Docker::Registry::IO';
+    use Moose;
+    with 'Docker::Registry::IO';
 
-  has response_to_return => (is => 'rw', isa => 'Docker::Registry::Response');
+    has response_to_return =>
+        (is => 'rw', isa => 'Docker::Registry::Response');
 
-  sub send_request {
-    my $self = shift;
-    return $self->response_to_return;
-  }
+    sub send_request {
+        my $self = shift;
+        return $self->response_to_return;
+    }
 }
 
 my $auth = Docker::Registry::Auth::None->new;
 
-my $io = TestIO::Fake->new(
-  response_to_return => response_200(''),
-);
+my $io = TestIO::Fake->new(response_to_return => response_200(''),);
 
 sub response_200 {
-  my ($content) = @_;
-  registry_response(200, $content);
+    my ($content) = @_;
+    registry_response(200, $content);
 }
 
 sub registry_response {
-  my ($status, $content) = @_;
-  return Docker::Registry::Response->new(
-    content => $content,
-    status => $status,
-    headers => {},
-  );
+    my ($status, $content) = @_;
+    return Docker::Registry::Response->new(
+        content => $content,
+        status  => $status,
+        headers => {},
+    );
 }
 
 my $d = Docker::Registry::Gitlab->new(
-    username => 'username',
-    password => 'password',
-    caller => $io,
-    auth   => $auth,
+    username     => 'username',
+    access_token => 'access_token',
+    caller       => $io,
+    auth         => $auth,
 );
 
 {
-  $io->response_to_return(
-    response_200('{"repositories":["test2-registry","test1-registry"]}'),
-  );
+    $io->response_to_return(
+        response_200('{"repositories":["test2-registry","test1-registry"]}'),
+    );
 
-throws_ok(
-    sub {
-        my $result = $d->repositories;
-        isa_ok($result, 'Docker::Registry::Result::Repositories');
-        cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
-        cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
-    },
-    qr/Unimplemented/,
-    "This doesn't work for now"
-);
+    throws_ok(
+        sub {
+            my $result = $d->repositories;
+            isa_ok($result, 'Docker::Registry::Result::Repositories');
+            cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
+            cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
+        },
+        qr/Unimplemented/,
+        "This doesn't work for now"
+    );
 
 }
 
 {
-  $io->response_to_return(
-    response_200('{"name":"test2-registry","tags":["version1"]}'), 
-  );
+    $io->response_to_return(
+        response_200('{"name":"test2-registry","tags":["version1"]}'),
+    );
 
-  my $result = $d->repository_tags(repository => 'test2-registry');
+    my $result = $d->repository_tags(repository => 'test2-registry');
 
-  isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
-  cmp_ok($result->name, 'eq', 'test2-registry');
-  cmp_ok($result->tags->[0], 'eq', 'version1');
+    isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
+    cmp_ok($result->name,      'eq', 'test2-registry');
+    cmp_ok($result->tags->[0], 'eq', 'version1');
 }
 
 done_testing;


### PR DESCRIPTION
Gitlab does not support the full implemenation of the Docker JWT
registry specs. So not everything can be supported [1].
What is supported is access to single repositories.

[1] https://gitlab.com/gitlab-org/gitlab-ce/issues/47497