### PR TITLE
Add builders and improve testsuite

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,5 @@
 local/
 cpanfile.snapshot
+/Docker-Registry-*.tar.gz
+/Docker-Registry-*/
+/Makefile

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,11 @@
+FROM perl:latest
+
+ENV DEBIAN_FRONTEND=noninteractive
+
+COPY cpanfile .
+RUN cpanm --installdeps .
+
+COPY . .
+
+RUN prove -lv t/*
+RUN cpanm .

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,0 +1,62 @@
+use strict;
+use warnings;
+
+use 5.014001;
+
+use ExtUtils::MakeMaker;
+
+my %WriteMakefileArgs = (
+  "ABSTRACT" => "A client for talking to Docker Registries",
+  "AUTHOR" => "Jose Luis Mart\x{ed}nez <joseluis.martinez\@capside.com>",
+  "CONFIGURE_REQUIRES" => {
+    "ExtUtils::MakeMaker" => 0
+  },
+  "DISTNAME" => "Docker-Registry",
+  "LICENSE" => "apache",
+  "MIN_PERL_VERSION" => "5.014001",
+  "NAME" => "Docker::Registry",
+  "PREREQ_PM" => {
+    "HTTP::Headers" => 0,
+    "HTTP::Tiny" => 0,
+    "IO::Socket::SSL" => 0,
+    "JSON::MaybeXS" => 0,
+    "Moose" => 0,
+    "MooseX::Types::Moose" => 0,
+    "Throwable::Error" => 0
+  },
+  "TEST_REQUIRES" => {
+    "Sub::Override" => 0,
+    "Test::Exception" => 0,
+    "Test::More" => 0
+  },
+  "VERSION" => "0.03",
+  "test" => {
+    "TESTS" => "t/*.t"
+  }
+);
+
+
+my %FallbackPrereqs = (
+  "HTTP::Headers" => 0,
+  "HTTP::Tiny" => 0,
+  "IO::Socket::SSL" => 0,
+  "JSON::MaybeXS" => 0,
+  "Moose" => 0,
+  "MooseX::Types::Moose" => 0,
+  "Sub::Override" => 0,
+  "Test::Exception" => 0,
+  "Test::More" => 0,
+  "Throwable::Error" => 0
+);
+
+
+unless ( eval { ExtUtils::MakeMaker->VERSION(6.63_03) } ) {
+  delete $WriteMakefileArgs{TEST_REQUIRES};
+  delete $WriteMakefileArgs{BUILD_REQUIRES};
+  $WriteMakefileArgs{PREREQ_PM} = \%FallbackPrereqs;
+}
+
+delete $WriteMakefileArgs{CONFIGURE_REQUIRES}
+  unless eval { ExtUtils::MakeMaker->VERSION(6.52) };
+
+WriteMakefile(%WriteMakefileArgs);

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -25,9 +25,9 @@ my %WriteMakefileArgs = (
     "Throwable::Error" => 0
   },
   "TEST_REQUIRES" => {
+    "Import::Into" => 0,
     "Sub::Override" => 0,
-    "Test::Exception" => 0,
-    "Test::More" => 0
+    "Test::Most" => 0
   },
   "VERSION" => "0.03",
   "test" => {
@@ -40,12 +40,12 @@ my %FallbackPrereqs = (
   "HTTP::Headers" => 0,
   "HTTP::Tiny" => 0,
   "IO::Socket::SSL" => 0,
+  "Import::Into" => 0,
   "JSON::MaybeXS" => 0,
   "Moose" => 0,
   "MooseX::Types::Moose" => 0,
   "Sub::Override" => 0,
-  "Test::Exception" => 0,
-  "Test::More" => 0,
+  "Test::Most" => 0,
   "Throwable::Error" => 0
 );
 

--- a/cpanfile
+++ b/cpanfile
@@ -5,6 +5,7 @@ requires 'HTTP::Tiny';
 requires 'HTTP::Headers';
 requires 'Throwable::Error';
 requires 'IO::Socket::SSL';
+requires 'MooseX::Types::Moose';
 
 feature 'gcr-registry', 'Support for GCR' => sub {
   requires 'Crypt::JWT';
@@ -12,13 +13,17 @@ feature 'gcr-registry', 'Support for GCR' => sub {
   requires 'URI';
 };
 
-feature 'ecr-registry', 'Support for ECR' => sub {
+feature 'ecr-registry', 'support for ecr' => sub {
   requires 'Paws';
+};
+
+feature 'gitlab-registry', 'support for gitlab' => sub {
 };
 
 on test => sub {
   requires 'Test::More';
   requires 'Test::Exception';
+  requires 'Sub::Override';
 };
 
 on develop => sub {

--- a/cpanfile
+++ b/cpanfile
@@ -31,4 +31,5 @@ on develop => sub {
   requires 'Dist::Zilla::Plugin::Prereqs::FromCPANfile';
   requires 'Dist::Zilla::Plugin::VersionFromModule';
   requires 'Dist::Zilla::PluginBundle::Git';
+  requires 'Dist::Zilla::Plugin::CopyFilesFromBuild::Filtered';
 };

--- a/cpanfile
+++ b/cpanfile
@@ -21,9 +21,9 @@ feature 'gitlab-registry', 'support for gitlab' => sub {
 };
 
 on test => sub {
-  requires 'Test::More';
-  requires 'Test::Exception';
+  requires 'Test::Most';
   requires 'Sub::Override';
+  requires 'Import::Into';
 };
 
 on develop => sub {

--- a/dist.ini
+++ b/dist.ini
@@ -15,10 +15,14 @@ dir = bin
 
 [MakeMaker]
 
+[CopyFilesFromBuild::Filtered]
+copy = Makefile.PL
+
 [@Git]
 allow_dirty = dist.ini
 allow_dirty = Changes
 allow_dirty = README
+allow_dirty = Makefile.PL
 
 [Prereqs::FromCPANfile]
 

--- a/examples/gitlab.pl
+++ b/examples/gitlab.pl
@@ -1,0 +1,27 @@
+#!/usr/bin/env perl
+
+use Data::Dumper;
+use Docker::Registry::Gitlab;
+use Docker::Registry::Auth::Gitlab;
+
+my $repo = $ARGV[0];
+
+my $r = Docker::Registry::Gitlab->new(
+    username => 'username',
+    password => 'personaltoken',
+    defined $repo ? (repo => $repo) : (),
+);
+
+$r->caller->debug(1);
+
+if (defined $repo) {
+    print Dumper($r->repository_tags(repository => $repo));
+}
+else {
+    my $repos = $r->repositories;
+    print Dumper($repos);
+
+    foreach my $r (@{ $repos->repositories }) {
+        print Dumper($r->repository_tags(repository => $r));
+    }
+}

--- a/examples/gitlab.pl
+++ b/examples/gitlab.pl
@@ -7,8 +7,8 @@ use Docker::Registry::Auth::Gitlab;
 my $repo = $ARGV[0];
 
 my $r = Docker::Registry::Gitlab->new(
-    username => 'username',
-    password => 'personaltoken',
+    username     => 'username',
+    access_token => 'personaltoken',
     defined $repo ? (repo => $repo) : (),
 );
 

--- a/lib/Docker/Registry/Auth/Gitlab.pm
+++ b/lib/Docker/Registry/Auth/Gitlab.pm
@@ -1,0 +1,152 @@
+package Docker::Registry::Auth::Gitlab;
+use Moose;
+use namespace::autoclean;
+
+# ABSTRACT: Authentication module for gitlab registry
+
+with 'Docker::Registry::Auth';
+
+use Docker::Registry::Types qw(DockerRegistryURI);
+use HTTP::Tiny;
+use JSON::MaybeXS qw(decode_json);
+
+has token => (
+    is       => 'ro',
+    isa      => 'Str',
+    lazy     => 1,
+    builder => 'get_token',
+);
+
+has username => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has password => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has jwt => (
+    is      => 'ro',
+    isa     => DockerRegistryURI,
+    coerce  => 1,
+    default => 'https://gitlab.com/jwt/auth',
+);
+
+has repo => (
+    is        => 'ro',
+    isa       => 'Str',
+    predicate => 'has_repo',
+);
+
+sub _build_scope {
+    my $self = shift;
+
+    if ($self->has_repo) {
+        return sprintf("repository:%s:pull,push", $self->repo);
+    }
+    else {
+        return 'registry:catalog:*';
+    }
+}
+
+sub _build_token_uri {
+    my $self = shift;
+
+    my $uri = $self->jwt->clone;
+
+    $uri->query_form(
+        service       => 'container_registry',
+        scope         => $self->_build_scope,
+        client_id     => 'docker',
+        offline_token => 'true',
+    );
+
+    $uri->userinfo(join(':', $self->username, $self->password));
+    return $uri;
+}
+
+sub get_token {
+    my $self = shift;
+
+    my $uri = $self->_build_token_uri;
+
+    my $ua = HTTP::Tiny->new();
+    my $res = $ua->get($uri);
+
+    if ($res->{success}) {
+        return decode_json($res->{content})->{token};
+    }
+
+    die "Unable to get token from gitlab!";
+}
+
+sub authorize {
+    my ($self, $request) = @_;
+
+    $request->header('Authorization', 'Bearer ' . $self->token);
+    $request->header('Accept',
+        'application/vnd.docker.distribution.manifest.v2+json');
+
+    return $request;
+}
+
+__PACKAGE__->meta->make_immutable;
+
+__END__
+
+=head1 DESCRIPTION
+
+Authenticate against gitlab registry
+
+=head1 SYNOPSIS
+
+    use Docker::Registry::Auth::Gitlab;
+    use HTTP::Tiny;
+
+    my $auth = Docker::Registry::Auth::Gitlab->new(
+        username => 'foo',
+        password => 'bar',
+    );
+
+    my $req = $auth->authorize(HTTP::Request->new('GET', 'https://foo.bar.nl'));
+    my $res = HTTP::Tiny->new()->get($req);
+
+=head1 ATTRIBUTES
+
+=head2 username
+
+Your username at gitlab.
+
+=head2 password
+
+The access token you get from
+L<gitlab|https://gitlab.com/profile/personal_access_tokens> with
+'read_registry' access.
+
+=head2 repo
+
+The repository you request access to.
+
+=head2 jwt
+
+The endpoint to request the JWT token from, defaults to
+'https://gitlab.com/jwt/auth'. You can use a 'Str' or an URI object.
+
+=head2 token
+
+The token received from gitlab.
+
+=head1 METHODS
+
+=head2 authorize
+
+Implements the method as required by C<Docker::Registry::Auth>. Add the
+"Authorization" header to the request with the "Bearer" token.
+
+=head2 SEE ALSO
+
+C<Docker::Registry::Auth>, C<Docker::Registery::Types> and C<Docker::Registry::Gitlab>.

--- a/lib/Docker/Registry/Auth/Gitlab.pm
+++ b/lib/Docker/Registry/Auth/Gitlab.pm
@@ -10,20 +10,13 @@ use Docker::Registry::Types qw(DockerRegistryURI);
 use HTTP::Tiny;
 use JSON::MaybeXS qw(decode_json);
 
-has token => (
-    is       => 'ro',
-    isa      => 'Str',
-    lazy     => 1,
-    builder => 'get_token',
-);
-
 has username => (
     is       => 'ro',
     isa      => 'Str',
     required => 1,
 );
 
-has password => (
+has access_token => (
     is       => 'ro',
     isa      => 'Str',
     required => 1,
@@ -41,6 +34,14 @@ has repo => (
     isa       => 'Str',
     predicate => 'has_repo',
 );
+
+has bearer_token => (
+    is       => 'ro',
+    isa      => 'Str',
+    lazy     => 1,
+    builder => 'get_bearer_token',
+);
+
 
 sub _build_scope {
     my $self = shift;
@@ -65,11 +66,11 @@ sub _build_token_uri {
         offline_token => 'true',
     );
 
-    $uri->userinfo(join(':', $self->username, $self->password));
+    $uri->userinfo(join(':', $self->username, $self->access_token));
     return $uri;
 }
 
-sub get_token {
+sub get_bearer_token {
     my $self = shift;
 
     my $uri = $self->_build_token_uri;
@@ -87,7 +88,7 @@ sub get_token {
 sub authorize {
     my ($self, $request) = @_;
 
-    $request->header('Authorization', 'Bearer ' . $self->token);
+    $request->header('Authorization', 'Bearer ' . $self->bearer_token);
     $request->header('Accept',
         'application/vnd.docker.distribution.manifest.v2+json');
 
@@ -109,7 +110,7 @@ Authenticate against gitlab registry
 
     my $auth = Docker::Registry::Auth::Gitlab->new(
         username => 'foo',
-        password => 'bar',
+        access_token => 'bar',
     );
 
     my $req = $auth->authorize(HTTP::Request->new('GET', 'https://foo.bar.nl'));
@@ -121,7 +122,7 @@ Authenticate against gitlab registry
 
 Your username at gitlab.
 
-=head2 password
+=head2 access_token
 
 The access token you get from
 L<gitlab|https://gitlab.com/profile/personal_access_tokens> with
@@ -136,11 +137,11 @@ The repository you request access to.
 The endpoint to request the JWT token from, defaults to
 'https://gitlab.com/jwt/auth'. You can use a 'Str' or an URI object.
 
-=head2 token
-
-The token received from gitlab.
-
 =head1 METHODS
+
+=head2 get_bearer_token
+
+The builder of the C<bearer_token> attribute.
 
 =head2 authorize
 

--- a/lib/Docker/Registry/Auth/Gitlab.pm
+++ b/lib/Docker/Registry/Auth/Gitlab.pm
@@ -144,9 +144,9 @@ The token received from gitlab.
 
 =head2 authorize
 
-Implements the method as required by C<Docker::Registry::Auth>. Add the
+Implements the method as required by L<Docker::Registry::Auth>. Add the
 "Authorization" header to the request with the "Bearer" token.
 
 =head2 SEE ALSO
 
-C<Docker::Registry::Auth>, C<Docker::Registery::Types> and C<Docker::Registry::Gitlab>.
+L<Docker::Registry::Auth>, L<Docker::Registery::Types> and L<Docker::Registry::Gitlab>.

--- a/lib/Docker/Registry/ECR.pm
+++ b/lib/Docker/Registry/ECR.pm
@@ -9,11 +9,11 @@ package Docker::Registry::ECR;
     sprintf 'https://%s.dkr.ecr.%s.amazonaws.com', $self->account_id, $self->region;
   });
 
-  has '+auth' => (lazy => 1, default => sub {
+  override build_auth => sub {
     my $self = shift;
     require Docker::Registry::Auth::ECR;
     Docker::Registry::Auth::ECR->new(region => $self->region);
-  });
+  };
 
   has account_id => (is => 'ro', isa => 'Str');
   has region => (is => 'ro', isa => 'Str');

--- a/lib/Docker/Registry/Gitlab.pm
+++ b/lib/Docker/Registry/Gitlab.pm
@@ -39,18 +39,16 @@ has 'repo' => (
     predicate => 'has_repo',
 );
 
-has '+auth' => (
-    lazy    => 1,
-    default => sub {
-        my $self = shift;
-        return Docker::Registry::Auth::Gitlab->new(
-            username     => $self->username,
-            access_token => $self->access_token,
-            $self->has_jwt  ? (jwt  => $self->jwt)  : (),
-            $self->has_repo ? (repo => $self->repo) : (),
-        );
-    },
-);
+override build_auth => sub {
+    my $self = shift;
+    require Docker::Registry::Auth::Gitlab;
+    return Docker::Registry::Auth::Gitlab->new(
+        username     => $self->username,
+        access_token => $self->access_token,
+        $self->has_jwt  ? (jwt  => $self->jwt)  : (),
+        $self->has_repo ? (repo => $self->repo) : (),
+    );
+};
 
 around 'repositories' => sub {
     my $orig = shift;

--- a/lib/Docker/Registry/Gitlab.pm
+++ b/lib/Docker/Registry/Gitlab.pm
@@ -21,7 +21,7 @@ has 'username' => (
     required => 1,
 );
 
-has 'password' => (
+has 'access_token' => (
     is       => 'ro',
     isa      => 'Str',
     required => 1,
@@ -44,10 +44,10 @@ has '+auth' => (
     default => sub {
         my $self = shift;
         return Docker::Registry::Auth::Gitlab->new(
-            username => $self->username,
-            password => $self->password,
-            $self->has_jwt ? ( jwt => $self->jwt ) : (),
-            $self->has_repo ? ( repo => $self->repo ) : (),
+            username     => $self->username,
+            access_token => $self->access_token,
+            $self->has_jwt  ? (jwt  => $self->jwt)  : (),
+            $self->has_repo ? (repo => $self->repo) : (),
         );
     },
 );
@@ -77,7 +77,7 @@ Connect and do things with the gitlab registry
     use Docker::Registry::Gitlab;
     my $registry = Docker::Registry::Gitlab->new(
         username => 'foo',
-        password => 'bar', # your private token at gitlab
+        access_token => 'bar', # your private token at gitlab
     );
 
 =head1 ATTRIBUTES
@@ -90,7 +90,7 @@ The endpoint of the registry, defaults to 'https://registry.gitlab.com'.
 
 Your username at gitlab
 
-=head2 password
+=head2 access_token
 
 The access token you get from
 L<gitlab|https://gitlab.com/profile/personal_access_tokens> with

--- a/lib/Docker/Registry/Gitlab.pm
+++ b/lib/Docker/Registry/Gitlab.pm
@@ -1,0 +1,123 @@
+package Docker::Registry::Gitlab;
+use Moose;
+extends 'Docker::Registry::V2';
+use namespace::autoclean;
+
+# ABSTRACT: Be able to talk to the gitlab registry
+
+use Docker::Registry::Types qw(DockerRegistryURI);
+
+has '+url' => (
+    lazy    => 1,
+    default => sub {
+        my $self = shift;
+        'https://registry.gitlab.com';
+    }
+);
+
+has 'username' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has 'password' => (
+    is       => 'ro',
+    isa      => 'Str',
+    required => 1,
+);
+
+has 'jwt' => (
+    is        => 'ro',
+    isa       => DockerRegistryURI,
+    predicate => 'has_jwt',
+);
+
+has 'repo' => (
+    is        => 'ro',
+    isa       => 'Str',
+    predicate => 'has_repo',
+);
+
+has '+auth' => (
+    lazy    => 1,
+    default => sub {
+        my $self = shift;
+        return Docker::Registry::Auth::Gitlab->new(
+            username => $self->username,
+            password => $self->password,
+            $self->has_jwt ? ( jwt => $self->jwt ) : (),
+            $self->has_repo ? ( repo => $self->repo ) : (),
+        );
+    },
+);
+
+around 'repositories' => sub {
+    my $orig = shift;
+    my $self = shift;
+
+    if ($ENV{GITLAB_SCOPE}) {
+        $self->$orig(@_);
+    }
+    else {
+        ...;
+    }
+};
+
+__PACKAGE__->meta->make_immutable;
+
+__END__
+
+=head1 DESCRIPTION
+
+Connect and do things with the gitlab registry
+
+=head1 SYNOPSIS
+
+    use Docker::Registry::Gitlab;
+    my $registry = Docker::Registry::Gitlab->new(
+        username => 'foo',
+        password => 'bar', # your private token at gitlab
+    );
+
+=head1 ATTRIBUTES
+
+=head2 url
+
+The endpoint of the registry, defaults to 'https://registry.gitlab.com'.
+
+=head2 username
+
+Your username at gitlab
+
+=head2 password
+
+The access token you get from
+L<gitlab|https://gitlab.com/profile/personal_access_tokens> with
+'read_registry' access.
+
+=head2 repo
+
+The repository you want to query.
+
+=head2 jwt
+
+The endpoint to request the JWT token from, if none supplied the default
+of L<Docker::Registry::Auth::Gitlab> will be used.
+
+=head1 METHODS
+
+=head2 repositories
+
+Unimplemented code path unless GITLAB_SCOPE is set as an environment variable.
+
+=head1 BUGS
+
+Because Gitlab doesn't support wild cards in scopes (yet!), you are not
+able to call certain functions. L<Docker::Registry::Gitlab/repositories>
+being one of them. For more information see:
+L<https://gitlab.com/gitlab-org/gitlab-ce/issues/47497>
+
+=head1 SEE ALSO
+
+L<Docker::Registry::Auth::Gitlab> and L<Docker::Registry::V2>.

--- a/lib/Docker/Registry/Types.pm
+++ b/lib/Docker/Registry/Types.pm
@@ -15,7 +15,7 @@ use MooseX::Types -declare => [
 class_type DockerRegistryURI, {class => 'URI' };
 coerce DockerRegistryURI, from Str, via { return URI->new($_); };
 
-__PACKAGE__->meta->make_immutable;
+1;
 
 __END__
 

--- a/lib/Docker/Registry/Types.pm
+++ b/lib/Docker/Registry/Types.pm
@@ -1,0 +1,45 @@
+package Docker::Registry::Types;
+use warnings;
+use strict;
+
+# ABSTRACT: Moose like types defined for Docker::Registry
+
+use MooseX::Types::Moose qw(Str);
+use URI;
+use MooseX::Types -declare => [
+    qw(
+        DockerRegistryURI
+    )
+];
+
+class_type DockerRegistryURI, {class => 'URI' };
+coerce DockerRegistryURI, from Str, via { return URI->new($_); };
+
+__PACKAGE__->meta->make_immutable;
+
+__END__
+
+=head1 DESCRIPTION
+
+Defines custom types for Docker::Registry modules
+
+=head1 SYNOPSIS
+
+    package Foo;
+    use Moose;
+
+    use Docker::Registry::Types qw(DockerRegistryURI);
+
+    has bar => (
+        is => 'ro',
+        isa => DockerRegistryURI,
+    );
+
+
+=head1 TYPES
+
+=head2 DockerRegistryURI
+
+Allows a scalar URI, eq 'https://foo.bar.nl', or a URI object.
+
+=cut

--- a/lib/Docker/Registry/V2.pm
+++ b/lib/Docker/Registry/V2.pm
@@ -28,10 +28,12 @@ package Docker::Registry::V2;
     require Docker::Registry::IO::Simple;
     Docker::Registry::IO::Simple->new;  
   });
-  has auth => (is => 'ro', does => 'Docker::Registry::Auth', default => sub {
+  has auth => (is => 'ro', does => 'Docker::Registry::Auth', lazy => 1, builder => 'build_auth' );
+
+  sub build_auth {
     require Docker::Registry::Auth::None;
     Docker::Registry::Auth::None->new; 
-  });
+  };
 
   use JSON::MaybeXS qw//;
   has _json => (is => 'ro', default => sub {

--- a/t/000-types.t
+++ b/t/000-types.t
@@ -1,0 +1,14 @@
+use warnings;
+use strict;
+
+use Test::More;
+
+use Docker::Registry::Types qw(DockerRegistryURI);
+use URI;
+
+my $uri = URI->new();
+ok(DockerRegistryURI->check($uri), "isa URI");
+ok(DockerRegistryURI->coerce('https://foo.bar.nl'), "coerced URI");
+
+
+done_testing;

--- a/t/02_ecr.t
+++ b/t/02_ecr.t
@@ -1,87 +1,52 @@
-#!/usr/bin/env perl
-
 use strict;
 use warnings;
-
-use Test::More;
-use Test::Exception;
+use lib qw(t/lib);
+use Test::Docker::Registry;
 
 use Docker::Registry::ECR;
-use Docker::Registry::Auth::None;
 
-package TestIO::Fake {
-  use Moose;
-  with 'Docker::Registry::IO';
-
-  has response_to_return => (is => 'rw', isa => 'Docker::Registry::Response');
-
-  sub send_request {
-    my $self = shift;
-    return $self->response_to_return;
-  }
-}
-
-my $auth = Docker::Registry::Auth::None->new;
-
-my $io = TestIO::Fake->new(
-  response_to_return => response_200(''),
-);
-
-sub response_200 {
-  my ($content) = @_;
-  registry_response(200, $content);
-}
-
-sub registry_response {
-  my ($status, $content) = @_;
-  return Docker::Registry::Response->new(
-    content => $content,
-    status => $status,
-    headers => {},
-  );
-}
+my $io   = new_fake_io();
+my $auth = new_auth_none();
 
 my $d = Docker::Registry::ECR->new(
-  caller => $io,
-  auth => $auth,
-  region => 'fake',
-  account_id => 'fake',
+    region     => 'fake',
+    account_id => 'fake',
+    caller     => $io,
+    auth       => $auth,
 );
 
 {
-  $io->response_to_return(
-    response_200('{"repositories":["test2-registry","test1-registry"]}'),
-  );
-  
-  my $result = $d->repositories;
+    $io->set_content('{"repositories":["test2-registry","test1-registry"]}');
 
-  isa_ok($result, 'Docker::Registry::Result::Repositories');
-  cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
-  cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
+    my $result = $d->repositories;
+
+    isa_ok($result, 'Docker::Registry::Result::Repositories');
+    cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
+    cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
 }
 
 {
-  $io->response_to_return(
-    response_200('{"name":"test2-registry","tags":["version1"]}'), 
-  );
-  
-  my $result = $d->repository_tags(repository => 'test2-registry');
+    $io->set_content('{"name":"test2-registry","tags":["version1"]}');
 
-  isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
-  cmp_ok($result->name, 'eq', 'test2-registry');
-  cmp_ok($result->tags->[0], 'eq', 'version1');
+    my $result = $d->repository_tags(repository => 'test2-registry');
+
+    isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
+    cmp_ok($result->name,      'eq', 'test2-registry');
+    cmp_ok($result->tags->[0], 'eq', 'version1');
 }
 
 {
-  $io->response_to_return(
-    registry_response(403, '{"errors":[{"code":"DENIED","message":"User: arn:aws:sts::012345678901:assumed-role/xxxxxxxxxxxx/xxxxxxxxxx@xxxxxxxxxxxxx is not authorized to perform: ecr:DescribeRepositories on resource: *"}]}'), 
-  );
+    $io->set_status_code(403);
+    $io->set_content(
+        '{"errors":[{"code":"DENIED","message":"User: arn:aws:sts::012345678901:assumed-role/xxxxxxxxxxxx/xxxxxxxxxx@xxxxxxxxxxxxx is not authorized to perform: ecr:DescribeRepositories on resource: *"}]}'
+    );
 
-  throws_ok(
-    sub { $d->repositories },
-    'Docker::Registry::Exception::HTTP',
-  );
-  cmp_ok($@->status, '==', 403);
+    throws_ok(
+        sub { $d->repositories },
+        'Docker::Registry::Exception::HTTP',
+        "An exception is returned by AWS"
+    );
+    is($@->status, 403, ".. and has the status code of 403");
 }
 
 done_testing;

--- a/t/03_gce.t
+++ b/t/03_gce.t
@@ -1,75 +1,39 @@
-#!/usr/bin/env perl
-
 use strict;
 use warnings;
+use lib qw(t/lib);
 
-use Test::More;
-use Test::Exception;
+use Test::Docker::Registry;
 
 use Docker::Registry::GCE;
-use Docker::Registry::Auth::None;
 
-package TestIO::Fake {
-  use Moose;
-  with 'Docker::Registry::IO';
-
-  has response_to_return => (is => 'rw', isa => 'Docker::Registry::Response');
-
-  sub send_request {
-    my $self = shift;
-    return $self->response_to_return;
-  }
-}
-
-my $auth = Docker::Registry::Auth::None->new;
-
-my $io = TestIO::Fake->new(
-  response_to_return => response_200(''),
-);
-
-sub response_200 {
-  my ($content) = @_;
-  registry_response(200, $content);
-}
-
-sub registry_response {
-  my ($status, $content) = @_;
-  return Docker::Registry::Response->new(
-    content => $content,
-    status => $status,
-    headers => {},
-  );
-}
+my $auth = new_auth_none();
+my $io   = new_fake_io();
 
 my $d = Docker::Registry::GCE->new(
-  caller => $io,
-  auth => $auth,
-  region => 'fake',
-  account_id => 'fake',
+    region     => 'fake',
+    account_id => 'fake',
+    caller     => $io,
+    auth       => $auth,
 );
 
 {
-  $io->response_to_return(
-    response_200('{"repositories":["test2-registry","test1-registry"]}'),
-  );
-  
-  my $result = $d->repositories;
+    $io->set_content('{"repositories":["test2-registry","test1-registry"]}');
 
-  isa_ok($result, 'Docker::Registry::Result::Repositories');
-  cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
-  cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
+    my $result = $d->repositories;
+
+    isa_ok($result, 'Docker::Registry::Result::Repositories');
+    cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
+    cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
 }
 
 {
-  $io->response_to_return(
-    response_200('{"name":"test2-registry","tags":["version1"]}'), 
-  );
-  
-  my $result = $d->repository_tags(repository => 'test2-registry');
+    $io->set_content('{"name":"test2-registry","tags":["version1"]}');
 
-  isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
-  cmp_ok($result->name, 'eq', 'test2-registry');
-  cmp_ok($result->tags->[0], 'eq', 'version1');
+    my $result = $d->repository_tags(repository => 'test2-registry');
+
+    isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
+    cmp_ok($result->name,      'eq', 'test2-registry');
+    cmp_ok($result->tags->[0], 'eq', 'version1');
 }
 
 done_testing;

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -69,7 +69,7 @@ SKIP: {
         . " test. Optionally set GITLAB_JWT if you want to test against a"
         . " self-hosted server. GITLAB_REPO can also be set.";
 
-    skip "LIVE tests" unless grep { /^GITLAB_/ } keys %ENV;
+    skip "LIVE tests", 1 unless grep { /^GITLAB_/ } keys %ENV;
 
     my $auth = Docker::Registry::Auth::Gitlab->new(
         username     => $ENV{GITLAB_USERNAME},

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -65,11 +65,12 @@ use Docker::Registry::Auth::Gitlab;
 
 SKIP: {
 
-    note "Live test, set GITLAB_USERNAME, GITLAB_access_token to run this"
-        . " test. Optionally set GITLAB_JWT if you want to test against a"
-        . " self-hosted server. GITLAB_REPO can also be set.";
+    my $msg = "Live test, set GITLAB_USERNAME, GITLAB_TOKEN to run this"
+    . " test. Optionally set GITLAB_JWT if you want to test against a"
+    . " self-hosted server. GITLAB_REPO can also be set.";
 
-    skip "LIVE tests", 1 unless grep { /^GITLAB_/ } keys %ENV;
+    skip($msg, 1) unless grep { /^GITLAB_/ } keys %ENV;
+    note "Running live tests";
 
     my $auth = Docker::Registry::Auth::Gitlab->new(
         username     => $ENV{GITLAB_USERNAME},

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -1,0 +1,85 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+use Sub::Override;
+use HTTP::Request;
+
+use Docker::Registry::Auth::Gitlab;
+
+{
+    my $auth = Docker::Registry::Auth::Gitlab->new(
+        username => 'foo',
+        password => 'bar',
+    );
+
+    my $jwt = $auth->jwt;
+    isa_ok($jwt, 'URI', "Got a JWT URI");
+
+    my $scope = $auth->_build_scope;
+    is($scope, 'registry:catalog:*', "scope is set to 'registry:catalog:*'");
+
+    {
+        # Cannot change the value, so bypass it :)
+        my $attr = $auth->meta->find_attribute_by_name('repo');
+        $attr->set_value($auth, 'foobar');
+
+        my $scope = $auth->_build_scope;
+        is($scope, 'repository:foobar:pull,push',
+            "scope is set to 'repository:foobar:pull,push'");
+    }
+
+    my $uri = $auth->_build_token_uri;
+    isa_ok($uri, 'URI', ".. and we have a token URI");
+    is($uri->host,     'gitlab.com', ".. with the correct hostname");
+    is($uri->userinfo, 'foo:bar',    ".. and the correct login details");
+
+    # Override HTTP::Tiny get so we don't need a network connection
+    my $override = Sub::Override->new(
+        "HTTP::Tiny::get" => sub {
+            return {
+                success => 1,
+                content => '{"token":"mysupersecrettoken"}',
+            };
+        }
+    );
+
+    is($auth->token, "mysupersecrettoken",
+        "Go the super secret token from gitlab!");
+
+    my $req = HTTP::Request->new('GET', $uri);
+    $req = $auth->authorize($req);
+
+    isa_ok($req, "HTTP::Request", "->authorize works too");
+    is(
+        $req->headers->header("authorization"),
+        "Bearer mysupersecrettoken",
+        ".. with the correct header"
+    );
+
+    $override->restore;
+}
+
+SKIP: {
+
+    note "Live test, set GITLAB_USERNAME, GITLAB_TOKEN to run this"
+    . " test. Optionally set GITLAB_JWT if you want to test against a"
+    . " self-hosted server. GITLAB_REPO can also be set.";
+
+    skip "LIVE tests" unless grep { /^GITLAB_/ } keys %ENV;
+
+    my $auth = Docker::Registry::Auth::Gitlab->new(
+        username => $ENV{GITLAB_USERNAME},
+        password => $ENV{GITLAB_TOKEN},
+        $ENV{GITLAB_JWT}  ? (jwt  => $ENV{GITLAB_JWT})  : (),
+        $ENV{GITLAB_REPO} ? (repo => $ENV{GITLAB_REPO}) : (),
+    );
+
+    my $token = $auth->token;
+    isnt($token, undef, "We got '$token' from gitlab");
+
+}
+done_testing;

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -12,8 +12,8 @@ use Docker::Registry::Auth::Gitlab;
 
 {
     my $auth = Docker::Registry::Auth::Gitlab->new(
-        username => 'foo',
-        password => 'bar',
+        username     => 'foo',
+        access_token => 'bar',
     );
 
     my $jwt = $auth->jwt;
@@ -33,7 +33,7 @@ use Docker::Registry::Auth::Gitlab;
     }
 
     my $uri = $auth->_build_token_uri;
-    isa_ok($uri, 'URI', ".. and we have a token URI");
+    isa_ok($uri, 'URI', ".. and we have a access_token URI");
     is($uri->host,     'gitlab.com', ".. with the correct hostname");
     is($uri->userinfo, 'foo:bar',    ".. and the correct login details");
 
@@ -42,12 +42,12 @@ use Docker::Registry::Auth::Gitlab;
         "HTTP::Tiny::get" => sub {
             return {
                 success => 1,
-                content => '{"token":"mysupersecrettoken"}',
+                content => '{"token":"mysupersecretaccess_token"}',
             };
         }
     );
 
-    is($auth->token, "mysupersecrettoken",
+    is($auth->bearer_token, "mysupersecretaccess_token",
         "Go the super secret token from gitlab!");
 
     my $req = HTTP::Request->new('GET', $uri);
@@ -56,7 +56,7 @@ use Docker::Registry::Auth::Gitlab;
     isa_ok($req, "HTTP::Request", "->authorize works too");
     is(
         $req->headers->header("authorization"),
-        "Bearer mysupersecrettoken",
+        "Bearer mysupersecretaccess_token",
         ".. with the correct header"
     );
 
@@ -65,20 +65,20 @@ use Docker::Registry::Auth::Gitlab;
 
 SKIP: {
 
-    note "Live test, set GITLAB_USERNAME, GITLAB_TOKEN to run this"
-    . " test. Optionally set GITLAB_JWT if you want to test against a"
-    . " self-hosted server. GITLAB_REPO can also be set.";
+    note "Live test, set GITLAB_USERNAME, GITLAB_access_token to run this"
+        . " test. Optionally set GITLAB_JWT if you want to test against a"
+        . " self-hosted server. GITLAB_REPO can also be set.";
 
     skip "LIVE tests" unless grep { /^GITLAB_/ } keys %ENV;
 
     my $auth = Docker::Registry::Auth::Gitlab->new(
-        username => $ENV{GITLAB_USERNAME},
-        password => $ENV{GITLAB_TOKEN},
+        username     => $ENV{GITLAB_USERNAME},
+        access_token => $ENV{GITLAB_TOKEN},
         $ENV{GITLAB_JWT}  ? (jwt  => $ENV{GITLAB_JWT})  : (),
         $ENV{GITLAB_REPO} ? (repo => $ENV{GITLAB_REPO}) : (),
     );
 
-    my $token = $auth->token;
+    my $token = $auth->bearer_token;
     isnt($token, undef, "We got '$token' from gitlab");
 
 }

--- a/t/400-gitlab.t
+++ b/t/400-gitlab.t
@@ -1,0 +1,81 @@
+#!/usr/bin/env perl
+
+use strict;
+use warnings;
+
+use Test::More;
+use Test::Exception;
+
+use Docker::Registry::Gitlab;
+use Docker::Registry::Auth::None;
+
+package TestIO::Fake {
+  use Moose;
+  with 'Docker::Registry::IO';
+
+  has response_to_return => (is => 'rw', isa => 'Docker::Registry::Response');
+
+  sub send_request {
+    my $self = shift;
+    return $self->response_to_return;
+  }
+}
+
+my $auth = Docker::Registry::Auth::None->new;
+
+my $io = TestIO::Fake->new(
+  response_to_return => response_200(''),
+);
+
+sub response_200 {
+  my ($content) = @_;
+  registry_response(200, $content);
+}
+
+sub registry_response {
+  my ($status, $content) = @_;
+  return Docker::Registry::Response->new(
+    content => $content,
+    status => $status,
+    headers => {},
+  );
+}
+
+my $d = Docker::Registry::Gitlab->new(
+    username => 'username',
+    password => 'password',
+    caller => $io,
+    auth   => $auth,
+);
+
+{
+  $io->response_to_return(
+    response_200('{"repositories":["test2-registry","test1-registry"]}'),
+  );
+
+throws_ok(
+    sub {
+        my $result = $d->repositories;
+        isa_ok($result, 'Docker::Registry::Result::Repositories');
+        cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
+        cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
+    },
+    qr/Unimplemented/,
+    "This doesn't work for now"
+);
+
+}
+
+{
+  $io->response_to_return(
+    response_200('{"name":"test2-registry","tags":["version1"]}'), 
+  );
+
+  my $result = $d->repository_tags(repository => 'test2-registry');
+
+  isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
+  cmp_ok($result->name, 'eq', 'test2-registry');
+  cmp_ok($result->tags->[0], 'eq', 'version1');
+}
+
+done_testing;

--- a/t/400-gitlab.t
+++ b/t/400-gitlab.t
@@ -10,72 +10,71 @@ use Docker::Registry::Gitlab;
 use Docker::Registry::Auth::None;
 
 package TestIO::Fake {
-  use Moose;
-  with 'Docker::Registry::IO';
+    use Moose;
+    with 'Docker::Registry::IO';
 
-  has response_to_return => (is => 'rw', isa => 'Docker::Registry::Response');
+    has response_to_return =>
+        (is => 'rw', isa => 'Docker::Registry::Response');
 
-  sub send_request {
-    my $self = shift;
-    return $self->response_to_return;
-  }
+    sub send_request {
+        my $self = shift;
+        return $self->response_to_return;
+    }
 }
 
 my $auth = Docker::Registry::Auth::None->new;
 
-my $io = TestIO::Fake->new(
-  response_to_return => response_200(''),
-);
+my $io = TestIO::Fake->new(response_to_return => response_200(''),);
 
 sub response_200 {
-  my ($content) = @_;
-  registry_response(200, $content);
+    my ($content) = @_;
+    registry_response(200, $content);
 }
 
 sub registry_response {
-  my ($status, $content) = @_;
-  return Docker::Registry::Response->new(
-    content => $content,
-    status => $status,
-    headers => {},
-  );
+    my ($status, $content) = @_;
+    return Docker::Registry::Response->new(
+        content => $content,
+        status  => $status,
+        headers => {},
+    );
 }
 
 my $d = Docker::Registry::Gitlab->new(
-    username => 'username',
-    password => 'password',
-    caller => $io,
-    auth   => $auth,
+    username     => 'username',
+    access_token => 'access_token',
+    caller       => $io,
+    auth         => $auth,
 );
 
 {
-  $io->response_to_return(
-    response_200('{"repositories":["test2-registry","test1-registry"]}'),
-  );
+    $io->response_to_return(
+        response_200('{"repositories":["test2-registry","test1-registry"]}'),
+    );
 
-throws_ok(
-    sub {
-        my $result = $d->repositories;
-        isa_ok($result, 'Docker::Registry::Result::Repositories');
-        cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
-        cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
-    },
-    qr/Unimplemented/,
-    "This doesn't work for now"
-);
+    throws_ok(
+        sub {
+            my $result = $d->repositories;
+            isa_ok($result, 'Docker::Registry::Result::Repositories');
+            cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
+            cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
+        },
+        qr/Unimplemented/,
+        "This doesn't work for now"
+    );
 
 }
 
 {
-  $io->response_to_return(
-    response_200('{"name":"test2-registry","tags":["version1"]}'), 
-  );
+    $io->response_to_return(
+        response_200('{"name":"test2-registry","tags":["version1"]}'),
+    );
 
-  my $result = $d->repository_tags(repository => 'test2-registry');
+    my $result = $d->repository_tags(repository => 'test2-registry');
 
-  isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
-  cmp_ok($result->name, 'eq', 'test2-registry');
-  cmp_ok($result->tags->[0], 'eq', 'version1');
+    isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
+    cmp_ok($result->name,      'eq', 'test2-registry');
+    cmp_ok($result->tags->[0], 'eq', 'version1');
 }
 
 done_testing;

--- a/t/400-gitlab.t
+++ b/t/400-gitlab.t
@@ -1,44 +1,13 @@
-#!/usr/bin/env perl
-
 use strict;
 use warnings;
+use lib qw(t/lib);
 
-use Test::More;
-use Test::Exception;
+use Test::Docker::Registry;
 
 use Docker::Registry::Gitlab;
-use Docker::Registry::Auth::None;
 
-package TestIO::Fake {
-    use Moose;
-    with 'Docker::Registry::IO';
-
-    has response_to_return =>
-        (is => 'rw', isa => 'Docker::Registry::Response');
-
-    sub send_request {
-        my $self = shift;
-        return $self->response_to_return;
-    }
-}
-
-my $auth = Docker::Registry::Auth::None->new;
-
-my $io = TestIO::Fake->new(response_to_return => response_200(''),);
-
-sub response_200 {
-    my ($content) = @_;
-    registry_response(200, $content);
-}
-
-sub registry_response {
-    my ($status, $content) = @_;
-    return Docker::Registry::Response->new(
-        content => $content,
-        status  => $status,
-        headers => {},
-    );
-}
+my $auth = new_auth_none();
+my $io   = new_fake_io();
 
 my $d = Docker::Registry::Gitlab->new(
     username     => 'username',
@@ -48,9 +17,7 @@ my $d = Docker::Registry::Gitlab->new(
 );
 
 {
-    $io->response_to_return(
-        response_200('{"repositories":["test2-registry","test1-registry"]}'),
-    );
+    $io->set_content('{"repositories":["test2-registry","test1-registry"]}');
 
     throws_ok(
         sub {
@@ -66,15 +33,13 @@ my $d = Docker::Registry::Gitlab->new(
 }
 
 {
-    $io->response_to_return(
-        response_200('{"name":"test2-registry","tags":["version1"]}'),
-    );
+    $io->set_content('{"name":"test2-registry","tags":["version1"]}');
 
     my $result = $d->repository_tags(repository => 'test2-registry');
 
-    isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
-    cmp_ok($result->name,      'eq', 'test2-registry');
-    cmp_ok($result->tags->[0], 'eq', 'version1');
+    isa_ok($result, 'Docker::Registry::Result::RepositoryTags', "Got the tags from the repository");
+    is($result->name, 'test2-registry', ".. and the name is correct");
+    cmp_deeply($result->tags, [qw(version1)], ".. and just one tag");;
 }
 
 done_testing;

--- a/t/lib/Test/Docker/Registry.pm
+++ b/t/lib/Test/Docker/Registry.pm
@@ -1,0 +1,50 @@
+package Test::Docker::Registry;
+use strict;
+use warnings;
+
+# ABSTRACT: A base test pacakge for Docker::Registry
+
+use namespace::autoclean ();
+
+use Import::Into;
+use Test::Fatal;
+use Test::Most;
+use Sub::Override;
+
+sub import {
+
+    my $caller_level = 1;
+
+    # Test::Most imports *ALL* functions of Test::Deep, Test::Deep has
+    # any, all, none, and some others that List::Utils also has.
+    # Test::Deep has EXPORT_TAGS but they include pretty much everything
+    my @TEST_DEEP_LIST_UTILS = qw(!any !all !none);
+    Test::Most->import::into($caller_level, @TEST_DEEP_LIST_UTILS);
+
+    my @imports = qw(
+        namespace::autoclean
+        Test::Fatal
+        Test::Docker::Registry::Util
+    );
+
+    $_->import::into($caller_level) for @imports;
+}
+
+1;
+
+__END__
+
+=head1 DESCRIPTION
+
+Imports all the stuff we want plus sets strict/warnings etc
+
+=head1 SYNOPSIS
+
+    use lib qw(t/lib);
+    use Test::Docker::Registry;
+
+    # tests here
+
+    done_testing;
+
+

--- a/t/lib/Test/Docker/Registry/Util.pm
+++ b/t/lib/Test/Docker/Registry/Util.pm
@@ -1,0 +1,67 @@
+package Test::Docker::Registry::Util;
+use strict;
+use warnings;
+
+use Exporter qw(import);
+
+our @EXPORT = qw(
+    new_fake_io
+    new_auth_none
+);
+
+use Docker::Registry::Auth::None;
+
+sub new_fake_io {
+    return Test::Docker::Registry::FakeIO->new();
+}
+
+sub new_auth_none {
+    return Docker::Registry::Auth::None->new();
+}
+
+package Test::Docker::Registry::FakeIO {
+    use Moose;
+    with 'Docker::Registry::IO';
+
+    has status_code => (
+        is      => 'rw',
+        isa     => 'Int',
+        default => 200,
+        writer  => 'set_status_code',
+        lazy    => 1,
+    );
+
+    has content => (
+        is      => 'rw',
+        isa     => 'Str',
+        writer  => 'set_content',
+        default => '',
+        lazy    => 1,
+    );
+
+    has headers => (
+        is      => 'rw',
+        isa     => 'HashRef',
+        writer  => 'set_headers',
+        lazy    => 1,
+        default => sub { {} },
+    );
+
+    has response_to_return => (
+        is  => 'rw',
+        isa => 'Docker::Registry::Response'
+    );
+
+    sub send_request {
+        my $self = shift;
+
+        return Docker::Registry::Response->new(
+            content => $self->content,
+            status  => $self->status_code,
+            headers => $self->headers,
+        );
+
+    }
+}
+
+1;


### PR DESCRIPTION
I've changed the 'auth' attribute to have a builder so consuming classes can 'override' the builder when needed. This is much easier to test than having a "complex" default. It also the prefered/advised way by Moose:
 
> This has several advantages. First, it moves a chunk of code to its own named method, which improves readability and code organization. Second, because this is a named method, it can be subclassed or provided by a role.
> 
> We strongly recommend that you use a builder instead of a default for anything beyond the most trivial default.

Secondly I've creatd t/lib/Test/Docker/Registry to provide a single testing module that does most of the work for us. It reduces the need to code cruft in the various .t files.

The PR is based on my gitlab branch (because of the builders). So the diff should be smaller once #3 is merged.
