### PR TITLE
Bump Import::Into min version to 1.002003

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -25,7 +25,7 @@ on test => sub {
   requires 'Test::Most';
   requires 'Test::Exception';
   requires 'Sub::Override';
-  requires 'Import::Into';
+  requires 'Import::Into' => '1.002003';
 };
 
 on develop => sub {

--- a/t/lib/Test/Docker/Registry.pm
+++ b/t/lib/Test/Docker/Registry.pm
@@ -7,9 +7,6 @@ use warnings;
 use namespace::autoclean ();
 
 use Import::Into;
-use Test::Fatal;
-use Test::Most;
-use Sub::Override;
 
 sub import {
 
@@ -23,8 +20,8 @@ sub import {
 
     my @imports = qw(
         namespace::autoclean
-        Test::Fatal
         Test::Docker::Registry::Util
+        Sub::Override
     );
 
     $_->import::into($caller_level) for @imports;


### PR DESCRIPTION
In t/lib/Test/Docker/Registry.pm we use Import::Into and import some
test functions from t/lib/Test/Docker/Registry/Util.pm. Versions before
1.002003 require us to 'use' the module before loading it with I::I. You
will otherwise see errors like this:

Undefined subroutine &main::new_auth_none called at t/03_gce.t line 9
Undefined subroutine &main::new_fake_io called at t/02_ecr.t line 8.

Thank you CPAN-testers for finding this!