### PR TITLE
Auth refactor

### DIFF
--- a/examples/azure-with-admin-account.pl
+++ b/examples/azure-with-admin-account.pl
@@ -1,0 +1,26 @@
+#!/usr/bin/env perl
+
+use Data::Dumper;
+use Docker::Registry::Azure;
+
+my $REPO_NAME = $ENV{REPO_NAME} or die "Please establish ENV REPO_NAME";
+my $REPO_PASS = $ENV{REPO_PASS} or die "Please establish ENV REPO_PASS";
+
+my $repo = $ARGV[0];
+
+my $r = Docker::Registry::Azure->new(
+  name => $REPO_NAME,
+  password => $REPO_PASS,
+);
+$r->caller->debug(1);
+
+if (defined $repo) {
+  print Dumper($r->repository_tags(repository => $repo));
+} else {
+  my $repos = $r->repositories;
+  print Dumper($repos);
+
+  foreach my $repo_name (@{ $repos->repositories }) {
+    print Dumper($r->repository_tags(repository => $repo_name));
+  }
+}

--- a/examples/azure-with-service-prinicipal.pl
+++ b/examples/azure-with-service-prinicipal.pl
@@ -1,0 +1,29 @@
+#!/usr/bin/env perl
+
+use Data::Dumper;
+use Docker::Registry::Azure;
+
+my $REPO_NAME = $ENV{REPO_NAME} or die "Please establish ENV REPO_NAME";
+
+die "Please define ENV AZURE_CLIENT_ID AZURE_SECRET_ID AZURE_TENANT_ID AZURE_SUBSCRIPTION_ID"
+  if (not defined $ENV{ AZURE_CLIENT_ID } or
+      not defined $ENV{ AZURE_SECRET_ID } or
+      not defined $ENV{ AZURE_TENANT_ID } or
+      not defined $ENV{ AZURE_SUBSCRIPTION_ID });
+
+my $repo = $ARGV[0];
+
+my $r = Docker::Registry::Azure->new(
+  name => $REPO_NAME,
+);
+
+if (defined $repo) {
+  print Dumper($r->repository_tags(repository => $repo));
+} else {
+  my $repos = $r->repositories;
+  print Dumper($repos);
+
+  foreach my $repo_name (@{ $repos->repositories }) {
+    print Dumper($r->repository_tags(repository => $repo_name));
+  }
+}

--- a/lib/Docker/Registry.pm
+++ b/lib/Docker/Registry.pm
@@ -67,9 +67,11 @@ Returns a L<Docker::Registry::Result::RepositoryTags> object with the list of ta
 Different cloud providers of Docker registries have subtle differences between them,
 so there are specialized classes for each supported provider:
 
-L<Docker::Registry::GCE>
+L<Docker::Registry::Azure>
 
 L<Docker::Registry::ECR>
+
+L<Docker::Registry::GCE>
 
 L<Docker::Registry::Gitlab>
 
@@ -79,9 +81,9 @@ Each registry class has it's authentication providers:
 
 L<Docker::Registry::Auth::Basic>
 
-L<Docker::Registry::Auth::GCEServiceAccount>
-
 L<Docker::Registry::Auth::ECR>
+
+L<Docker::Registry::Auth::GCEServiceAccount>
 
 L<Docker::Registry::Auth::Gitlab>
 

--- a/lib/Docker/Registry/Auth/AzureServicePrincipal.pm
+++ b/lib/Docker/Registry/Auth/AzureServicePrincipal.pm
@@ -1,0 +1,71 @@
+package Docker::Registry::Auth::AzureServicePrincipal;
+  use Moose;
+  with 'Docker::Registry::Auth';
+  use JSON::MaybeXS;
+
+  use Azure::AD::ClientCredentials;
+  has ad_auth => (
+    is => 'ro',
+    default => sub {
+      Azure::AD::ClientCredentials->new(
+        resource_id => "https://management.core.windows.net/",       
+      );
+    }
+  );
+
+  has ua => (is => 'ro', default => sub { HTTP::Tiny->new(timeout => 20) });
+
+  sub authorize {
+    my ($self, $request, $scope) = @_;
+
+    my ($login_server) = ($request->url =~ m|//(.*?)/v2|);
+    die "Can't detect login_server from " . $request->url if (not defined $login_server);
+
+    my $challenge = $self->ua->get("https://$login_server/v2/");
+    die "Registry didn't issue a challenge" if ($challenge->{ status } != 401);
+    die "Registry didn't issue a challenge" if (not defined $challenge->{ headers }->{ 'www-authenticate' });
+
+    my $authenticate = $challenge->{ headers }->{ 'www-authenticate' };
+    my @tokens = split / /, $authenticate, 2;
+    die "Registry doesn't support AAD login" if (@tokens < 2 or lc($tokens[0]) ne 'bearer');
+    
+    my %params = map { my @kv = split /=/, $_; $kv[1] =~ s/"//g; ($kv[0] => $kv[1])  } split /,/, $tokens[1];
+    if (not defined $params{ realm } or not defined $params{ service }) {
+      die "Registry doesn't support AAD login"
+    }
+
+    my $authhost = $params{ realm };
+    $authhost =~ s|/oauth2/token|/oauth2/exchange|;
+
+    my $response = $self->ua->post_form(
+      $authhost,
+      {
+        grant_type => 'access_token',
+        service => $params{ service },
+        tenant => $self->ad_auth->tenant_id,
+        access_token => $self->ad_auth->access_token
+      }
+    );
+
+    die "Access to registry was denied. Response code: $response->{ status }" if (not $response->{ success });
+
+    my $refresh_token = decode_json($response->{ content })->{ refresh_token };
+
+    $response = $self->ua->post_form(
+      $params{ realm },
+      {
+        grant_type => 'refresh_token',
+        service => $params{ service },
+        scope => $scope,
+        refresh_token => $refresh_token,
+      }
+    );
+
+    my $access_token = decode_json($response->{ content })->{ access_token };
+
+    $request->header('Authorization', 'Bearer ' . $access_token);
+
+    return $request;
+  }
+
+1;

--- a/lib/Docker/Registry/Auth/Gitlab.pm
+++ b/lib/Docker/Registry/Auth/Gitlab.pm
@@ -29,38 +29,14 @@ has jwt => (
     default => 'https://gitlab.com/jwt/auth',
 );
 
-has repo => (
-    is        => 'ro',
-    isa       => 'Str',
-    predicate => 'has_repo',
-);
-
-has bearer_token => (
-    is       => 'ro',
-    isa      => 'Str',
-    lazy     => 1,
-    builder => 'get_bearer_token',
-);
-
-sub _build_scope {
-    my $self = shift;
-
-    if ($self->has_repo) {
-        return sprintf("repository:%s:pull,push", $self->repo);
-    }
-    else {
-        return 'registry:catalog:*';
-    }
-}
-
 sub _build_token_uri {
-    my $self = shift;
+    my ($self, $scope) = @_;
 
     my $uri = $self->jwt->clone;
 
     $uri->query_form(
         service       => 'container_registry',
-        scope         => $self->_build_scope,
+        scope         => $scope,
         client_id     => 'docker',
         offline_token => 'true',
     );
@@ -70,9 +46,9 @@ sub _build_token_uri {
 }
 
 sub get_bearer_token {
-    my $self = shift;
+    my ($self, $scope) = @_;
 
-    my $uri = $self->_build_token_uri;
+    my $uri = $self->_build_token_uri($scope);
 
     my $ua = HTTP::Tiny->new();
     my $res = $ua->get($uri);
@@ -85,9 +61,11 @@ sub get_bearer_token {
 }
 
 sub authorize {
-    my ($self, $request) = @_;
+    my ($self, $request, $scope) = @_;
 
-    $request->header('Authorization', 'Bearer ' . $self->bearer_token);
+    my $bearer_token = $self->set_bearer_token($scope);
+
+    $request->header('Authorization', 'Bearer ' . $bearer_token);
     $request->header('Accept',
         'application/vnd.docker.distribution.manifest.v2+json');
 

--- a/lib/Docker/Registry/Azure.pm
+++ b/lib/Docker/Registry/Azure.pm
@@ -1,0 +1,29 @@
+package Docker::Registry::Azure;
+  use Moose;
+  extends 'Docker::Registry::V2';
+
+  has '+url' => (lazy => 1, default => sub {
+    my $self = shift;
+    die "Must specify name" if (not defined $self->name);
+    sprintf 'https://%s.azurecr.io', $self->name;
+  });
+
+  override build_auth => sub {
+    my $self = shift;
+    if (defined $self->password) {
+      # We're using the "Admin Account" mode
+      # https://docs.microsoft.com/en-us/azure/container-registry/container-registry-authentication#admin-account
+      require Docker::Registry::Auth::Basic;
+      Docker::Registry::Auth::Basic->new(
+        username => $self->name,
+        password => $self->password,
+      );
+    } else {
+      die "Cannot authenticate";
+    }
+  };
+
+  has name => (is => 'ro', isa => 'Str');
+  has password => (is => 'ro', isa => 'Str');
+
+1;

--- a/lib/Docker/Registry/Azure.pm
+++ b/lib/Docker/Registry/Azure.pm
@@ -19,7 +19,9 @@ package Docker::Registry::Azure;
         password => $self->password,
       );
     } else {
-      die "Cannot authenticate";
+      # We're using Service Principal mode
+      require Docker::Registry::Auth::AzureServicePrincipal;
+      Docker::Registry::Auth::AzureServicePrincipal->new;
     }
   };
 

--- a/lib/Docker/Registry/Gitlab.pm
+++ b/lib/Docker/Registry/Gitlab.pm
@@ -46,7 +46,6 @@ override build_auth => sub {
         username     => $self->username,
         access_token => $self->access_token,
         $self->has_jwt  ? (jwt  => $self->jwt)  : (),
-        $self->has_repo ? (repo => $self->repo) : (),
     );
 };
 

--- a/lib/Docker/Registry/V2.pm
+++ b/lib/Docker/Registry/V2.pm
@@ -86,7 +86,8 @@ package Docker::Registry::V2;
       method => 'GET',
       url => (join '/', $self->url, $self->api_base, '_catalog')
     );
-    $request = $self->auth->authorize($request);
+    my $scope = 'registry:catalog:*';
+    $request = $self->auth->authorize($request, $scope);
     my $response = $self->caller->send_request($request);
     my $result_class = 'Docker::Registry::Result::Repositories';
     my $result = $result_class->new($self->process_json_response($response));
@@ -112,7 +113,8 @@ package Docker::Registry::V2;
       method => 'GET',
       url => (join '/', $self->url, $self->api_base, $call->repository, 'tags/list')
     );
-    $request = $self->auth->authorize($request);
+    my $scope = sprintf 'repository:%s:%s', $call->repository, 'pull';
+    $request = $self->auth->authorize($request, $scope);
     my $response = $self->caller->send_request($request);
     my $result_class = 'Docker::Registry::Result::RepositoryTags';
     my $result = $result_class->new($self->process_json_response($response));

--- a/t/04_azure.t
+++ b/t/04_azure.t
@@ -1,0 +1,57 @@
+use strict;
+use warnings;
+use lib qw(t/lib);
+
+use Test::Docker::Registry;
+
+use Docker::Registry::Azure;
+
+my $io   = new_fake_io();
+
+my $d = Docker::Registry::Azure->new(
+    name       => 'azure-repo',    
+    caller     => $io,
+    password => 'MyPass',
+);
+
+cmp_ok($d->url, 'eq', 'https://azure-repo.azurecr.io');
+
+{
+    $io->set_content('{"repositories":["test2-registry","test1-registry"]}');
+
+    my $result = $d->repositories;
+
+    isa_ok($result, 'Docker::Registry::Result::Repositories');
+    cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
+    cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
+}
+
+{
+    $io->set_content('{"name":"test2-registry","tags":["version1"]}');
+
+    my $result = $d->repository_tags(repository => 'test2-registry');
+
+    isa_ok($result, 'Docker::Registry::Result::RepositoryTags');
+    cmp_ok($result->name,      'eq', 'test2-registry');
+    cmp_ok($result->tags->[0], 'eq', 'version1');
+}
+
+{
+    $io->set_status_code(400);
+    $io->set_content(
+        '<html><head><title>400 Bad Request</title></head><body bgcolor="white"><center><h1>400 Bad Request</h1></center><hr><center>nginx</center></body></html>'
+    );
+
+    throws_ok(
+        sub { $d->repositories },
+        'Docker::Registry::Exception::HTTP',
+        "A 400 error message is returned by the serice"
+    );
+    is($@->status, 400, ".. and has the status code of 400");
+}
+
+
+use Data::Dumper;
+print Dumper($d);
+
+done_testing;


### PR DESCRIPTION
@waterkip: this affects the Gitlab module, which I don't have means to try.

Implementing an Azure Container Registry module, I've found out that it's more practical to send the scope to the authenticate module (that way you can call methods for different repositories, and the scopes will automatically be calculated for you.

I've tried to adapt the Gitlab module. Can you try out this branch to see if this has impacted it's functionality?