### PR TITLE
Update testsuite a bit

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,6 +31,7 @@ my %WriteMakefileArgs = (
     "Sub::Override" => 0,
     "Test::Deep" => 0,
     "Test::Exception" => 0,
+    "Test::Lib" => 0,
     "Test::More" => 0,
     "Test::Most" => 0
   },

--- a/cpanfile
+++ b/cpanfile
@@ -29,5 +29,6 @@ on test => sub {
   requires 'Sub::Override';
   requires 'Import::Into' => '1.002003';
   requires 'Test::Deep';
+  requires 'Test::Lib';
 };
 

--- a/t/02_ecr.t
+++ b/t/02_ecr.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
-use lib qw(t/lib);
+
+use Test::Lib;
 use Test::Docker::Registry;
 
 use Docker::Registry::ECR;

--- a/t/03_gce.t
+++ b/t/03_gce.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
-use lib qw(t/lib);
-
+use Test::Lib;
 use Test::Docker::Registry;
 
 use Docker::Registry::GCE;

--- a/t/04_azure.t
+++ b/t/04_azure.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
-use lib qw(t/lib);
-
+use Test::Lib;
 use Test::Docker::Registry;
 
 use Docker::Registry::Azure;

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -1,12 +1,10 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
+use lib qw(t/lib);
+use Test::Docker::Registry;
 
-use Test::More;
-use Test::Exception;
 use Test::Deep;
-use Sub::Override;
 use HTTP::Request;
 
 use Docker::Registry::Auth::Gitlab;

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use lib qw(t/lib);
+use Test::Lib;
 use Test::Docker::Registry;
 
 use Test::Deep;

--- a/t/400-gitlab.t
+++ b/t/400-gitlab.t
@@ -2,8 +2,7 @@
 
 use strict;
 use warnings;
-use lib qw(t/lib);
-
+use Test::Lib;
 use Test::Docker::Registry;
 
 use Docker::Registry::Gitlab;


### PR DESCRIPTION
I had this in a branch of mine, the first commit is making a .t file use the Test::Docker::Registry module and the second commit is changing `use qw(t/lib)` to `use Test::Lib`, which deals with this in a more elegant way.

I rebased it on release/0.06