### PR TITLE
Add CONTRIBUTORS file to the module

### DIFF
--- a/CONTRIBUTORS
+++ b/CONTRIBUTORS
@@ -1,0 +1,14 @@
+
+# DOCKER-REGISTRY CONTRIBUTORS #
+
+This is the (likely incomplete) list of people who have helped
+make this distribution what it is, either via code contributions, 
+patches, bug reports, help with troubleshooting, etc. A huge
+'thank you' to all of them.
+
+    * Jose Luis Martinez
+    * Wesley Schwengle
+    * Oriol Soriano
+    * Mohammad S Anwar
+
+

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -31,6 +31,7 @@ my %WriteMakefileArgs = (
     "Sub::Override" => 0,
     "Test::Deep" => 0,
     "Test::Exception" => 0,
+    "Test::Lib" => 0,
     "Test::More" => 0,
     "Test::Most" => 0
   },

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -53,6 +53,7 @@ my %FallbackPrereqs = (
   "Sub::Override" => 0,
   "Test::Deep" => 0,
   "Test::Exception" => 0,
+  "Test::Lib" => 0,
   "Test::More" => 0,
   "Test::Most" => 0,
   "Throwable::Error" => 0,

--- a/cpanfile
+++ b/cpanfile
@@ -29,5 +29,6 @@ on test => sub {
   requires 'Sub::Override';
   requires 'Import::Into' => '1.002003';
   requires 'Test::Deep';
+  requires 'Test::Lib';
 };
 

--- a/dist.ini
+++ b/dist.ini
@@ -10,6 +10,7 @@ main_module = lib/Docker/Registry.pm
 [Git::GatherDir]
 exclude_match=Makefile
 exclude_match=LICENSE
+exclude_match=CONTRIBUTORS
 
 [ExecDir]
 dir = bin
@@ -18,6 +19,7 @@ dir = bin
 
 [CopyFilesFromBuild::Filtered]
 copy = Makefile.PL
+copy = CONTRIBUTORS
 
 [@Git]
 allow_dirty = dist.ini
@@ -37,6 +39,11 @@ repository.type = git
 bugtracker.web = https://github.com/pplu/docker-registry/issues
 
 [License]
+[Git::Contributors]
+order_by = commits
+
+[ContributorsFile]
+filename = CONTRIBUTORS
 
 ;[RunExtraTests]
 ;[TestRelease]

--- a/lib/Docker/Registry.pm
+++ b/lib/Docker/Registry.pm
@@ -28,44 +28,49 @@ Docker::Registry - A client for talking to Docker Registries
 
 =head1 DESCRIPTION
 
-This module helps you talk to different Docker Registries from different cloud providers.
+This module helps you talk to different Docker Registries from different cloud
+providers.
 
-Docker Registry APIs are standard, but authentication methods differ from vendor to vendor.
-This set of modules helps manage that for you.
+Docker Registry APIs are standard, but authentication methods differ from
+vendor to vendor.  This set of modules helps manage that for you.
 
 =head1 WARNING
 
-Consider this code Alpha quality. It works, but only some read-only methods have been implemented, and the API
-may still change. Be careful if you start depending on this module.
+Consider this code Alpha quality. It works, but only some read-only methods
+have been implemented, and the API may still change. Be careful if you start
+depending on this module.
 
 =head1 ATTRIBUTES
 
 =head2 url
 
-The URL of the registry. Most of the time this URL is automatically derived by provider classes 
-like (L<Docker::Registry::ECR>.
+The URL of the registry. Most of the time this URL is automatically derived by
+provider classes like (L<Docker::Registry::ECR>.
 
 =head2 auth
 
-An instance of an object that has the L<Docker::Registry::Auth> Role. See AUTHENTICATION for 
-a list of authentication types. Subclasses (like L<Docker::Registry::GCE>) will set a default
-authentication object appropiate for the specific provider. This is left injectable in the 
-constructor so the programmer can force a specific auth provider.
+An instance of an object that has the L<Docker::Registry::Auth> Role. See
+AUTHENTICATION for a list of authentication types. Subclasses (like
+L<Docker::Registry::GCE>) will set a default authentication object appropiate
+for the specific provider. This is left injectable in the constructor so the
+programmer can force a specific auth provider.
 
 =head1 METHODS
 
 =head2 repositories
 
-Returns a L<Docker::Registry::Result::Repositories> object with the list of repositories
+Returns a L<Docker::Registry::Result::Repositories> object with the list of
+repositories
 
 =head2 repository_tags(name => $repo_name)
 
-Returns a L<Docker::Registry::Result::RepositoryTags> object with the list of tags
+Returns a L<Docker::Registry::Result::RepositoryTags> object with the list of
+tags
 
 =head1 PROVIDERS
 
-Different cloud providers of Docker registries have subtle differences between them,
-so there are specialized classes for each supported provider:
+Different cloud providers of Docker registries have subtle differences between
+them, so there are specialized classes for each supported provider:
 
 L<Docker::Registry::Azure>
 
@@ -87,8 +92,8 @@ L<Docker::Registry::Auth::GCEServiceAccount>
 
 L<Docker::Registry::Auth::Gitlab>
 
-The most of the time the specialized provider tries to select the appropiate authentication
-module, but it can be overrided with the C<auth> attribute 
+The most of the time the specialized provider tries to select the appropiate
+authentication module, but it can be overrided with the C<auth> attribute
 
 =head1 SEE ALSO
 

--- a/lib/Docker/Registry.pm
+++ b/lib/Docker/Registry.pm
@@ -100,9 +100,13 @@ L<https://docs.docker.com/registry/spec/api/>
     CAPSiDE
     jlmartinez@capside.com
 
-=head1 Contributors
+=head1 CONTRIBUTORS
 
-Wesley Schwengle (waterkip) has implemented the GitLab provider, as well as refactored code
+Wesley Schwengle (waterkip) has implemented the GitLab provider, as well as
+refactored code
+
+For a full list of all the contributors see the CONTRIBUTORS file included in
+this module.
 
 =head1 BUGS and SOURCE
 

--- a/t/02_ecr.t
+++ b/t/02_ecr.t
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
-use lib qw(t/lib);
+
+use Test::Lib;
 use Test::Docker::Registry;
 
 use Docker::Registry::ECR;

--- a/t/03_gce.t
+++ b/t/03_gce.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
-use lib qw(t/lib);
-
+use Test::Lib;
 use Test::Docker::Registry;
 
 use Docker::Registry::GCE;

--- a/t/04_azure.t
+++ b/t/04_azure.t
@@ -1,7 +1,6 @@
 use strict;
 use warnings;
-use lib qw(t/lib);
-
+use Test::Lib;
 use Test::Docker::Registry;
 
 use Docker::Registry::Azure;

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -1,12 +1,10 @@
 #!/usr/bin/env perl
-
 use strict;
 use warnings;
+use lib qw(t/lib);
+use Test::Docker::Registry;
 
-use Test::More;
-use Test::Exception;
 use Test::Deep;
-use Sub::Override;
 use HTTP::Request;
 
 use Docker::Registry::Auth::Gitlab;

--- a/t/400-gitlab-auth.t
+++ b/t/400-gitlab-auth.t
@@ -1,7 +1,7 @@
 #!/usr/bin/env perl
 use strict;
 use warnings;
-use lib qw(t/lib);
+use Test::Lib;
 use Test::Docker::Registry;
 
 use Test::Deep;

--- a/t/400-gitlab.t
+++ b/t/400-gitlab.t
@@ -2,8 +2,7 @@
 
 use strict;
 use warnings;
-use lib qw(t/lib);
-
+use Test::Lib;
 use Test::Docker::Registry;
 
 use Docker::Registry::Gitlab;


### PR DESCRIPTION
Let distzilla create/update and maintain the CONTIBUTORS for the module.

Includes line rewrapping in a seperate commit to have everything < 80 chars.