### PR TITLE
Implement result pagination

### DIFF
--- a/cpanfile
+++ b/cpanfile
@@ -30,5 +30,7 @@ on test => sub {
   requires 'Import::Into' => '1.002003';
   requires 'Test::Deep';
   requires 'Test::Lib';
+  requires 'Test::Spec';
+  requires 'Test::Spec::Mocks';
 };
 

--- a/lib/Docker/Registry/RequestBuilder.pm
+++ b/lib/Docker/Registry/RequestBuilder.pm
@@ -1,0 +1,35 @@
+package Docker::Registry::RequestBuilder;
+  use Moo;
+
+  use Docker::Registry::Request;
+  use Docker::Registry::Types qw(DockerRegistryURI);
+
+  has url => (is => 'ro', coerce => 1, isa => DockerRegistryURI, required => 1);
+  has api_base => (is => 'ro', default => 'v2');
+
+  sub build_request {
+    my ($self, $call) = @_;
+    my $request;
+
+    if (ref($call) eq 'Docker::Registry::Call::Repositories') {
+      $request = Docker::Registry::Request->new(
+        method => 'GET',
+        url => (join '/', $self->url, $self->api_base, '_catalog')
+      );
+
+    } elsif (ref($call) eq 'Docker::Registry::Call::RepositoryTags') {
+      $request = Docker::Registry::Request->new(
+        method => 'GET',
+        url => (join '/', $self->url, $self->api_base, $call->repository, 'tags/list')
+      );
+    } else {
+      Docker::Exception->throw(
+        message => sprintf("Unknown call class: %s", ref($call)),
+      );
+    }
+
+    return $request;
+  }
+
+
+1;

--- a/lib/Docker/Registry/RequestBuilder.pm
+++ b/lib/Docker/Registry/RequestBuilder.pm
@@ -12,15 +12,21 @@ package Docker::Registry::RequestBuilder;
     my $request;
 
     if (ref($call) eq 'Docker::Registry::Call::Repositories') {
+      my $url = join '/', $self->url, $self->api_base, '_catalog';
+      $url .= "?n=".$call->n  if($call->n);
+
       $request = Docker::Registry::Request->new(
         method => 'GET',
-        url => (join '/', $self->url, $self->api_base, '_catalog')
+        url => $url,
       );
 
     } elsif (ref($call) eq 'Docker::Registry::Call::RepositoryTags') {
+      my $url = join '/', $self->url, $self->api_base, $call->repository, 'tags/list';
+      $url .= "?n=".$call->n  if($call->n);
+
       $request = Docker::Registry::Request->new(
         method => 'GET',
-        url => (join '/', $self->url, $self->api_base, $call->repository, 'tags/list')
+        url => $url,
       );
     } else {
       Docker::Exception->throw(

--- a/lib/Docker/Registry/V2.pm
+++ b/lib/Docker/Registry/V2.pm
@@ -104,11 +104,8 @@ package Docker::Registry::V2;
     # }
     my $call_class = 'Docker::Registry::Call::Repositories';
     my $call = $call_class->new({ @_ });
-    my $params = { };
-    $params->{ n } = $call->n if (defined $call->n);
-    $params->{ last } = $call->last if (defined $call->last);
 
-    my $request = $self->request_builder->build_request($call, $params);
+    my $request = $self->request_builder->build_request($call);
 
     my $scope = 'registry:catalog:*';
     $request = $self->auth->authorize($request, $scope);
@@ -127,12 +124,8 @@ package Docker::Registry::V2;
     #{"name":"$repository","tags":["2017.09","latest"]}
     my $call_class = 'Docker::Registry::Call::RepositoryTags';
     my $call = $call_class->new({ @_ });
-    my $params = { };
 
-    $params->{ n } = $call->n if (defined $call->n);
-    $params->{ last } = $call->last if (defined $call->last);
-
-    my $request = $self->request_builder->build_request($call, $params);
+    my $request = $self->request_builder->build_request($call);
 
     my $scope = sprintf 'repository:%s:%s', $call->repository, 'pull';
     $request = $self->auth->authorize($request, $scope);

--- a/lib/Docker/Registry/V2.pm
+++ b/lib/Docker/Registry/V2.pm
@@ -1,8 +1,8 @@
 package Docker::Registry::Call::Repositories;
   use Moo;
-  use Types::Standard qw/Int/;
+  use Types::Standard qw/Int Str/;
   has n => (is => 'ro', isa => Int);
-  has limit => (is => 'ro', isa => Int);
+  has last => (is => 'ro', isa => Str);
 
 package Docker::Registry::Result::Repositories;
   use Moo;
@@ -14,7 +14,7 @@ package Docker::Registry::Call::RepositoryTags;
   use Types::Standard qw/Int Str/;
   has repository => (is => 'ro', isa => Str, required => 1);
   has n => (is => 'ro', isa => Int);
-  has limit => (is => 'ro', isa => Int);
+  has last => (is => 'ro', isa => Str);
 
 package Docker::Registry::Result::RepositoryTags;
   use Moo;
@@ -90,7 +90,7 @@ package Docker::Registry::V2;
     my $call = $call_class->new({ @_ });
     my $params = { };
     $params->{ n } = $call->n if (defined $call->n);
-    $params->{ limit } = $call->limit if (defined $call->limit);
+    $params->{ last } = $call->last if (defined $call->last);
 
     my $request = $self->request_builder->build_request($call, $params);
 
@@ -114,7 +114,7 @@ package Docker::Registry::V2;
     my $params = { };
 
     $params->{ n } = $call->n if (defined $call->n);
-    $params->{ limit } = $call->limit if (defined $call->limit);
+    $params->{ last } = $call->last if (defined $call->last);
 
     my $request = $self->request_builder->build_request($call, $params);
 

--- a/t/05_pagination.t
+++ b/t/05_pagination.t
@@ -1,0 +1,89 @@
+#!/usr/bin/env perl
+use strict;
+use warnings;
+use Test::Spec;
+use Test::Spec::Mocks;
+use JSON::MaybeXS 'encode_json';
+
+use Docker::Registry::V2;
+use Docker::Registry::Request;
+use Docker::Registry::Response;
+
+
+describe "'n' parameter" => sub {
+  my $d = Docker::Registry::V2->new(
+      url => 'https://my.awesome.registry',
+  );
+  my $repository = 'my-repository';
+  my ($expected_request, $stubbed_response);
+
+  describe "When it is not passed" => sub {
+    before each => sub {
+      $expected_request = _request({ repository => $repository });
+      $stubbed_response = _response();
+      $d->caller
+        ->expects('send_request')
+        ->with_deep($expected_request)
+        ->returns($stubbed_response);
+    };
+
+    it 'is not added to the request & the result is correctly parsed' => sub {
+      my $result = $d->repository_tags(repository => $repository);
+      cmp_ok($result->name, 'eq', $repository);
+      is_deeply($result->tags, ['v1','v2']);
+    };
+  };
+
+  describe "When it is passed" => sub {
+    before each => sub {
+      $expected_request = _request({ repository => $repository, n => 101 });
+      $stubbed_response = _response({ n => 101 });
+      $d->caller
+        ->expects('send_request')
+        ->with_deep($expected_request)
+        ->returns($stubbed_response);
+    };
+
+    it 'is added to the request & the result is correctly parsed' => sub {
+      my $result = $d->repository_tags(repository => $repository, n => 101);
+      cmp_ok($result->name, 'eq', $repository);
+      is_deeply($result->tags, [map { "v$_" } (1..101)]);
+    };
+  };
+};
+
+runtests unless caller;
+
+
+sub _request {
+  my $args = shift;
+
+  my $url = join '/', 'https://my.awesome.registry', 'v2', $args->{repository}, 'tags/list';
+
+  return Docker::Registry::Request->new(
+    method => 'GET',
+    url => $args->{n}
+      ? "$url?n=$args->{n}"
+      : $url,
+  );
+}
+
+
+sub _response {
+  my $args = shift;
+  my $n = $args->{n} || 2;
+
+  return Docker::Registry::Response->new(
+    status => 200,
+    headers => {
+      'docker-distribution-api-version' => 'registry/2.0',
+      'date' => 'Wed, 21 Oct 2015 07:28:00 GMT',
+      'transfer-encoding' => 'chunked',
+      'content-type' => 'text/plain; charset=utf-8',
+      'connection' => 'keep-alive',
+    },
+    content => $args->{content}
+      ? encode_json($args->{content})
+      : encode_json({ name => 'my-repository', tags =>  [map { "v$_" } (1..$n)] }),
+  );
+}

--- a/t/05_pagination.t
+++ b/t/05_pagination.t
@@ -10,44 +10,90 @@ use Docker::Registry::Request;
 use Docker::Registry::Response;
 
 
-describe "'n' parameter" => sub {
+describe 'Pagination' => sub {
   my $d = Docker::Registry::V2->new(
       url => 'https://my.awesome.registry',
   );
   my $repository = 'my-repository';
   my ($expected_request, $stubbed_response);
 
-  describe "When it is not passed" => sub {
-    before each => sub {
-      $expected_request = _request({ repository => $repository });
-      $stubbed_response = _response();
-      $d->caller
-        ->expects('send_request')
-        ->with_deep($expected_request)
-        ->returns($stubbed_response);
+  describe "'n' parameter" => sub {
+    describe "When it is not passed" => sub {
+      before all => sub {
+        $expected_request = _request({ repository => $repository });
+        $stubbed_response = _response();
+        $d->caller
+          ->expects('send_request')
+          ->with_deep($expected_request)
+          ->returns($stubbed_response);
+      };
+
+      it 'is not added to the request & the result is correctly parsed' => sub {
+        my $result = $d->repository_tags(repository => $repository);
+        cmp_ok($result->name, 'eq', $repository);
+        is_deeply($result->tags, ['v1','v2']);
+      };
     };
 
-    it 'is not added to the request & the result is correctly parsed' => sub {
-      my $result = $d->repository_tags(repository => $repository);
-      cmp_ok($result->name, 'eq', $repository);
-      is_deeply($result->tags, ['v1','v2']);
+    describe "When it is passed" => sub {
+      before each => sub {
+        $expected_request = _request({ repository => $repository, n => 101 });
+        $stubbed_response = _response({ n => 101 });
+        $d->caller
+          ->expects('send_request')
+          ->with_deep($expected_request)
+          ->returns($stubbed_response);
+      };
+
+      it 'is added to the request & the result is correctly parsed' => sub {
+        my $result = $d->repository_tags(repository => $repository, n => 101);
+        cmp_ok($result->name, 'eq', $repository);
+        is_deeply($result->tags, [map { "v$_" } (1..101)]);
+      };
     };
   };
 
-  describe "When it is passed" => sub {
-    before each => sub {
-      $expected_request = _request({ repository => $repository, n => 101 });
-      $stubbed_response = _response({ n => 101 });
-      $d->caller
-        ->expects('send_request')
-        ->with_deep($expected_request)
-        ->returns($stubbed_response);
+  describe "'last' parameter" => sub {
+    describe "When it is not passed" => sub {
+      before each => sub {
+        $expected_request = _request({ repository => $repository });
+        $stubbed_response = _response();
+        $d->caller
+          ->expects('send_request')
+          ->with_deep($expected_request)
+          ->returns($stubbed_response);
+      };
+
+      it 'is not added to the request & the result is correctly parsed' => sub {
+        my $result = $d->repository_tags(repository => $repository);
+        cmp_ok($result->name, 'eq', $repository);
+        is_deeply($result->tags, ['v1','v2']);
+        ok(!$result->last);
+      };
     };
 
-    it 'is added to the request & the result is correctly parsed' => sub {
-      my $result = $d->repository_tags(repository => $repository, n => 101);
-      cmp_ok($result->name, 'eq', $repository);
-      is_deeply($result->tags, [map { "v$_" } (1..101)]);
+    describe "When it is passed" => sub {
+      my $result;
+      my $last = 'ukD72mdD/mC8b5xV3susmJzzaTgp';
+
+      before all => sub {
+        $expected_request = _request({ repository => $repository, last => $last });
+        $stubbed_response = _response({ last => $last });
+        $d->caller
+          ->expects('send_request')
+          ->with_deep($expected_request)
+          ->returns($stubbed_response);
+      };
+
+      it 'is added to the request & the result is correctly parsed' => sub {
+       $result = $d->repository_tags(repository => $repository, last => $last);
+        cmp_ok($result->name, 'eq', $repository);
+        is_deeply($result->tags, [map { "v$_" } (1..2)]);
+      };
+
+      it "the received 'last' value in the 'Link' header is returned in the result object" => sub {
+        cmp_ok($result->last, 'eq', $last);
+      };
     };
   };
 };
@@ -55,16 +101,24 @@ describe "'n' parameter" => sub {
 runtests unless caller;
 
 
+use URI;
 sub _request {
   my $args = shift;
+  my $url  = URI->new(join '/', 'https://my.awesome.registry', 'v2', $args->{repository}, 'tags/list');
 
-  my $url = join '/', 'https://my.awesome.registry', 'v2', $args->{repository}, 'tags/list';
+  if ($args->{n} or $args->{last}) {
+    if ($args->{n} and !$args->{last}) {
+      $url->query_form(n => $args->{n});
+    } elsif (!$args->{n} and $args->{last}) {
+      $url->query_form(last => $args->{last});
+    } else {
+      $url->query_form(last => $args->{last}, n => $args->{n});
+    }
+  }
 
   return Docker::Registry::Request->new(
     method => 'GET',
-    url => $args->{n}
-      ? "$url?n=$args->{n}"
-      : $url,
+    url => $url->as_string,
   );
 }
 
@@ -81,6 +135,9 @@ sub _response {
       'transfer-encoding' => 'chunked',
       'content-type' => 'text/plain; charset=utf-8',
       'connection' => 'keep-alive',
+      $args->{last}
+        ? (link => "<https://my.awesome.registry/v2/my-repository/tags/list?last=$args->{last}&n=1000>; rel='next'")
+        : (),
     },
     content => $args->{content}
       ? encode_json($args->{content})


### PR DESCRIPTION
This changeset is a proposal on how to implement support for the following Docker Registry V2 API functionality around pagination: 
* `n` parameter.
* `last` parameter.
* Retrieving `last` value from the response header & setting it on the result object.
  
More info: https://docs.docker.com/registry/spec/api/#listing-repositories