### PR TITLE
Gitlab now supports repositories

### DIFF
--- a/lib/Docker/Registry/Gitlab.pm
+++ b/lib/Docker/Registry/Gitlab.pm
@@ -50,9 +50,6 @@ around build_auth => sub {
     );
 };
 
-around 'repositories' => sub {
-  die "_catalog operation is not supported by GitLab provider";
-};
 
 __PACKAGE__->meta->make_immutable;
 

--- a/t/400-gitlab.t
+++ b/t/400-gitlab.t
@@ -20,16 +20,10 @@ my $d = Docker::Registry::Gitlab->new(
 {
     $io->set_content('{"repositories":["test2-registry","test1-registry"]}');
 
-    throws_ok(
-        sub {
-            my $result = $d->repositories;
-            isa_ok($result, 'Docker::Registry::Result::Repositories');
-            cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
-            cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
-        },
-        qr/not supported by GitLab/,
-        "GitLab doesn't support repositories method"
-    );
+    my $result = $d->repositories;
+    isa_ok($result, 'Docker::Registry::Result::Repositories');
+    cmp_ok($result->repositories->[0], 'eq', 'test2-registry');
+    cmp_ok($result->repositories->[1], 'eq', 'test1-registry');
 }
 
 {


### PR DESCRIPTION
There seems to be a small bug, but it appears Gitlab has added support for the repositories call. We haven't seen it because we disabled the method.

Signed-off-by: Wesley Schwengle <wesley@opndev.io>